### PR TITLE
Refactor get length into read resource

### DIFF
--- a/api/tests-static/test_client.cc
+++ b/api/tests-static/test_client.cc
@@ -9,7 +9,6 @@ int staticClientProcessBootstrapTimeout = 10;
 
 }
 
-
 namespace Awa {
 
 class TestStaticClient : public testing::Test
@@ -42,7 +41,7 @@ TEST_F(TestStaticClient, AwaStaticClient_New_Init_Unconfigured_Client)
     EXPECT_TRUE(client == NULL);
 }
 
-TEST_F(TestStaticClient, AwaStaticClient_SetBootstrapServerURI_vaild_input)
+TEST_F(TestStaticClient, AwaStaticClient_SetBootstrapServerURI_valid_input)
 {
     AwaStaticClient * client = AwaStaticClient_New();
     EXPECT_TRUE(client != NULL);
@@ -53,7 +52,7 @@ TEST_F(TestStaticClient, AwaStaticClient_SetBootstrapServerURI_vaild_input)
     EXPECT_TRUE(client == NULL);
 }
 
-TEST_F(TestStaticClient, AwaStaticClient_SetBootstrapServerURI_invaild_input)
+TEST_F(TestStaticClient, AwaStaticClient_SetBootstrapServerURI_invalid_input)
 {
     AwaStaticClient * client = AwaStaticClient_New();
     EXPECT_TRUE(client != NULL);
@@ -65,7 +64,7 @@ TEST_F(TestStaticClient, AwaStaticClient_SetBootstrapServerURI_invaild_input)
     EXPECT_TRUE(client == NULL);
 }
 
-TEST_F(TestStaticClient, AwaStaticClient_SetEndPointName_vaild_input)
+TEST_F(TestStaticClient, AwaStaticClient_SetEndPointName_valid_input)
 {
     AwaStaticClient * client = AwaStaticClient_New();
     EXPECT_TRUE(client != NULL);
@@ -76,7 +75,7 @@ TEST_F(TestStaticClient, AwaStaticClient_SetEndPointName_vaild_input)
     EXPECT_TRUE(client == NULL);
 }
 
-TEST_F(TestStaticClient, AwaStaticClient_SetEndPointName_invaild_input)
+TEST_F(TestStaticClient, AwaStaticClient_SetEndPointName_invalid_input)
 {
     AwaStaticClient * client = AwaStaticClient_New();
     EXPECT_TRUE(client != NULL);
@@ -99,7 +98,7 @@ TEST_F(TestStaticClient, AwaStaticClient_SetEndPointName_long_name)
     EXPECT_TRUE(client == NULL);
 }
 
-TEST_F(TestStaticClient, AwaStaticClient_SetCOAPListenAddressPort_vaild_input)
+TEST_F(TestStaticClient, AwaStaticClient_SetCOAPListenAddressPort_valid_input)
 {
     AwaStaticClient * client = AwaStaticClient_New();
     EXPECT_TRUE(client != NULL);
@@ -110,7 +109,7 @@ TEST_F(TestStaticClient, AwaStaticClient_SetCOAPListenAddressPort_vaild_input)
     EXPECT_TRUE(client == NULL);
 }
 
-TEST_F(TestStaticClient, AwaStaticClient_SetCOAPListenAddressPort_invaild_input)
+TEST_F(TestStaticClient, AwaStaticClient_SetCOAPListenAddressPort_invalid_input)
 {
     AwaStaticClient * client = AwaStaticClient_New();
     EXPECT_TRUE(client != NULL);
@@ -160,6 +159,7 @@ TEST_F(TestStaticClient, AwaStaticClient_Init_valid_inputs)
     EXPECT_TRUE(client == NULL);
 }
 
+//This test is for valgrind
 TEST_F(TestStaticClient, AwaStaticClient_Process)
 {
     AwaStaticClient * client = AwaStaticClient_New();
@@ -171,6 +171,9 @@ TEST_F(TestStaticClient, AwaStaticClient_Process)
 
     EXPECT_EQ(AwaError_Success, AwaStaticClient_Init(client));
 
+    AwaStaticClient_Process(client);
+    AwaStaticClient_Process(client);
+    AwaStaticClient_Process(client);
     AwaStaticClient_Process(client);
 
     AwaStaticClient_Free(&client);

--- a/core/src/bootstrap/lwm2m_bootstrap_core.c
+++ b/core/src/bootstrap/lwm2m_bootstrap_core.c
@@ -103,15 +103,10 @@ int Lwm2mCore_CreateOptionalResource(Lwm2mContextType * context, ObjectIDType ob
     return (ObjectStore_CreateResource(context->Store, objectID, objectInstanceID, resourceID) == -1) ? -1 : 0;
 }
 
-int Lwm2mCore_GetResourceInstanceLength(Lwm2mContextType * context, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID, ResourceIDType resourceID, ResourceInstanceIDType resourceInstanceID)
-{
-    return ObjectStore_GetResourceInstanceLength(context->Store, objectID, objectInstanceID, resourceID, resourceInstanceID);
-}
-
 int Lwm2mCore_GetResourceInstanceValue(Lwm2mContextType * context, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID, ResourceIDType resourceID, 
-                                       ResourceInstanceIDType resourceInstanceID, void * destBuffer, int destBufferLen)
+                                       ResourceInstanceIDType resourceInstanceID, const void ** buffer, int * bufferLen)
 {
-    return ObjectStore_GetResourceInstanceValue(((Lwm2mContextType *)(context))->Store, objectID, objectInstanceID, resourceID, resourceInstanceID, destBuffer, destBufferLen);
+    return ObjectStore_GetResourceInstanceValue(((Lwm2mContextType *)(context))->Store, objectID, objectInstanceID, resourceID, resourceInstanceID, buffer, bufferLen);
 }
 
 ObjectInstanceIDType Lwm2mCore_GetNextObjectInstanceID(Lwm2mContextType * context, ObjectIDType  objectID, ObjectInstanceIDType objectInstanceID)

--- a/core/src/bootstrap/lwm2m_core.h
+++ b/core/src/bootstrap/lwm2m_core.h
@@ -56,7 +56,7 @@ void Lwm2mCore_Destroy(Lwm2mContextType * context);
 
 // The following functions are called by other parts of the system to "Operate" on a resource
 int Lwm2mCore_GetResourceInstanceValue(Lwm2mContextType * context, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID, ResourceIDType resourceID,
-                                       ResourceInstanceIDType resourceInstanceID, void * Value, int ValueBufferSize);
+                                       ResourceInstanceIDType resourceInstanceID, const void ** buffer, int * bufferLen);
 
 int Lwm2mCore_GetResourceInstanceLength(Lwm2mContextType * context, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID, ResourceIDType resourceID, ResourceInstanceIDType resourceInstanceID);
 int Lwm2mCore_GetResourceInstanceCount(Lwm2mContextType * context, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID, ResourceIDType resourceID);

--- a/core/src/client/lwm2m_client_xml_handlers.c
+++ b/core/src/client/lwm2m_client_xml_handlers.c
@@ -617,27 +617,14 @@ static AwaError AddResourceInstanceToGetResponse(Lwm2mContextType * context, int
     AwaError result = AwaError_Unspecified;
     int outLength;
     char * dataValue = NULL;
-    char * buffer = NULL;
+    const char * buffer = NULL;
 
     ResourceTypeType dataType = Definition_GetResourceType(Lwm2mCore_GetDefinitions(context), objectID, resourceID);
     if (dataType != ResourceTypeEnum_TypeNone)
     {
-        // Determine buffer size required to read entire resource instance contents
-        int dataLength = Lwm2mCore_GetResourceInstanceLength(context, objectID, instanceID, resourceID, resourceInstanceID);
-        if (dataLength < 0)
-        {
-            result = AwaError_PathNotFound;
-            goto error;
-        }
+        int dataLength = 0;
 
-        buffer = malloc(dataLength);
-        if (buffer == NULL)
-        {
-            result = AwaError_Internal;
-            goto error;
-        }
-
-        outLength = Lwm2mCore_GetResourceInstanceValue(context, objectID, instanceID, resourceID, resourceInstanceID, buffer, dataLength);
+        outLength = Lwm2mCore_GetResourceInstanceValue(context, objectID, instanceID, resourceID, resourceInstanceID, (const void **)&buffer, &dataLength);
         //Lwm2m_Debug("GET /%d/%d/%d[%d]: outLength %d, dataLength %d\n", objectID, instanceID, resourceID, resourceInstanceID, outLength, dataLength);
         if (outLength < 0)
         {
@@ -654,8 +641,6 @@ static AwaError AddResourceInstanceToGetResponse(Lwm2mContextType * context, int
                 goto error;
             }
         }
-
-        free(buffer);
     }
 
     TreeNode valueNode = Xml_CreateNode("Value");

--- a/core/src/client/lwm2m_core.h
+++ b/core/src/client/lwm2m_core.h
@@ -76,9 +76,8 @@ void Lwm2mCore_Destroy(Lwm2mContextType * context);
 
 // The following functions are called by other parts of the system to "Operate" on a resource
 int Lwm2mCore_GetResourceInstanceValue(Lwm2mContextType * context, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID, ResourceIDType resourceID,
-                                       ResourceInstanceIDType resourceInstanceID, void * Value, int ValueBufferSize);
+                                       ResourceInstanceIDType resourceInstanceID, const void ** Value, int * ValueBufferSize);
 
-int Lwm2mCore_GetResourceInstanceLength(Lwm2mContextType * context, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID, ResourceIDType resourceID, ResourceInstanceIDType resourceInstanceID);
 int Lwm2mCore_GetResourceInstanceCount(Lwm2mContextType * context, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID, ResourceIDType resourceID);
 
 int Lwm2mCore_CreateObjectInstance(Lwm2mContextType * context, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID);

--- a/core/src/client/lwm2m_static.c
+++ b/core/src/client/lwm2m_static.c
@@ -94,7 +94,7 @@ AwaError AwaStaticClient_Init(AwaStaticClient * client)
     {
         if (client->COAPConfigured && client->BootstrapConfigured && client->EndpointNameConfigured)
         {
-            client->COAP = coap_Init(client->COAPListenAddress, client->COAPListenPort, DebugLevel_Info);
+            client->COAP = coap_Init(client->COAPListenAddress, client->COAPListenPort, DebugLevel_Debug);
 
             if (client->COAP != NULL)
             {
@@ -251,3 +251,13 @@ int AwaStaticClient_Process(AwaStaticClient * client)
 
     return result;
 }
+
+
+//AwaError AwaStaticClient_RegisterObject(AwaStaticClient * client, const char * objectName, AwaObjectID objectID,
+//                                          uint16_t minimumInstances, uint16_t maximumInstances)
+//{
+//    ObjectOperationHandlers * handlers = NULL;
+//    ObjectDefinition * defintion = Definition_NewObjectType(objectName, objectID, maximumInstances, minimumInstances, handlers);
+//}
+
+

--- a/core/src/common/lwm2m_debug.c
+++ b/core/src/common/lwm2m_debug.c
@@ -26,7 +26,7 @@
 
 #include "lwm2m_debug.h"
 
-static DebugLevel debugLevel = DebugLevel_Info;
+static DebugLevel debugLevel = DebugLevel_Debug;
 static FILE * g_outFile = NULL;
 
 static const char * logLabels[] = { "EMER", "ALERT", "CRIT", "ERROR", "WARN", "NOTICE", "INFO", "DEBUG" };

--- a/core/src/common/lwm2m_definition.h
+++ b/core/src/common/lwm2m_definition.h
@@ -42,7 +42,7 @@ extern "C" {
 
 // handler to call to retrieve a value from a resource instance
 typedef int (*ReadHandler)(void * context, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID, ResourceIDType resourceID,
-                           ResourceInstanceIDType resourceInstanceID, uint8_t * destBuffer, int destBufferLen);
+                           ResourceInstanceIDType resourceInstanceID, const void ** buffer, int * bufferLen);
 
 typedef int (*GetLengthHandler)(void * context, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID,
                                 ResourceIDType resourceID, ResourceInstanceIDType resourceInstanceID);
@@ -69,7 +69,7 @@ typedef struct
     WriteHandler Write;
     ReadHandler Read;
     ExecuteHandler Execute;
-    GetLengthHandler GetLength;
+    //GetLengthHandler GetLength;
     CreateOptionalResourceHandler CreateOptionalResource;
 } ResourceOperationHandlers;
 

--- a/core/src/common/lwm2m_object_store.c
+++ b/core/src/common/lwm2m_object_store.c
@@ -334,7 +334,7 @@ int ObjectStore_GetResourceInstanceLength(ObjectStore * store, ObjectIDType obje
 }
 
 int ObjectStore_GetResourceInstanceValue(ObjectStore * store, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID,
-                                         ResourceIDType resourceID, ResourceInstanceIDType resourceInstanceID, void * ValueBuffer, int ValueBufferSize)
+                                         ResourceIDType resourceID, ResourceInstanceIDType resourceInstanceID, const void ** ValueBuffer, int * ValueBufferSize)
 {
     Resource * resource = LookupResource(store, objectID, objectInstanceID, resourceID);
     if (resource != NULL)
@@ -345,20 +345,15 @@ int ObjectStore_GetResourceInstanceValue(ObjectStore * store, ObjectIDType objec
             Lwm2mResult_SetResult(Lwm2mResult_NotFound);
             return -1;
         }
-        else if (ValueBuffer == NULL)
+        else if (ValueBuffer == NULL || ValueBufferSize == NULL)
         {
-            Lwm2m_Error("ValueBuffer is NULL");
+            Lwm2m_Error("ValueBuffer or ValueBufferSize is NULL\n");
             Lwm2mResult_SetResult(Lwm2mResult_InternalError);
             return -1;
         }
-        else if (ValueBufferSize < instance->Size)
-        {
-            Lwm2m_Error("ValueBuffer is smaller than the size of the requested resource instance (%d < %d)", ValueBufferSize, instance->Size);
-            Lwm2mResult_SetResult(Lwm2mResult_BadRequest);
-            return -1;
-        }
 
-        memcpy(ValueBuffer, instance->Value, instance->Size);
+        *ValueBuffer = instance->Value;
+        *ValueBufferSize = instance->Size;
         Lwm2mResult_SetResult(Lwm2mResult_Success);
         return instance->Size;
     }

--- a/core/src/common/lwm2m_object_store.h
+++ b/core/src/common/lwm2m_object_store.h
@@ -44,7 +44,7 @@ ObjectStore * ObjectStore_Create(void);
 int ObjectStore_GetResourceInstanceLength(ObjectStore * store, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID,
                                           ResourceIDType resourceID, ResourceInstanceIDType resourceInstanceID);
 int ObjectStore_GetResourceInstanceValue(ObjectStore * store, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID,
-                                         ResourceIDType resourceID, ResourceInstanceIDType resourceInstanceID, void * ValueBuffer, int ValueBufferSize);
+                                         ResourceIDType resourceID, ResourceInstanceIDType resourceInstanceID, const void ** ValueBuffer, int * ValueBufferSize);
 int ObjectStore_SetResourceInstanceValue(ObjectStore * store, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID,
                                          ResourceIDType resourceID, ResourceInstanceIDType resourceInstanceID, int valueSize,
                                          const void * valueBuffer, int valueBufferPos, int valueBufferLen, bool * changed);

--- a/core/src/common/lwm2m_observers.c
+++ b/core/src/common/lwm2m_observers.c
@@ -315,12 +315,16 @@ int Lwm2m_Observe(void * ctxt, AddressType * addr, const char * token, int token
 
         if ((resourceDefinition != NULL) && (!IS_MULTIPLE_INSTANCE(resourceDefinition)))
         {
-            observer->OldValueLength = Lwm2mCore_GetResourceInstanceLength(context, objectID, objectInstanceID, resourceID, 0);
-            if (observer->OldValueLength > 0)
+            const void * oldValue = NULL;
+            int oldValueLength = 0;
+
+            Lwm2mCore_GetResourceInstanceValue(context, objectID, objectInstanceID, resourceID, 0, &oldValue, &oldValueLength);
+
+            if (oldValueLength > 0 && oldValue != NULL)
             {
-                //Lwm2m_Debug("Observer->OldValueLength = %d\n", observer->OldValueLength);
+                observer->OldValueLength = oldValueLength;
                 observer->OldValue = malloc(observer->OldValueLength);
-                Lwm2mCore_GetResourceInstanceValue(context, objectID, objectInstanceID, resourceID, 0, observer->OldValue, observer->OldValueLength);
+                memcpy(observer->OldValue, oldValue, observer->OldValueLength);
             }
         }
     }

--- a/core/src/common/lwm2m_tree_builder.c
+++ b/core/src/common/lwm2m_tree_builder.c
@@ -46,30 +46,13 @@ static Lwm2mResult TreeBuilder_ReadResourceInstanceFromStoreAndCreateTree(Lwm2mT
 {
     Lwm2mResult result = Lwm2mResult_Unspecified;
     *dest = Lwm2mTreeNode_Create();
-    void * value = NULL;
+    const void * value = NULL;
     int valueLength;
 
     Lwm2mTreeNode_SetID(*dest, resourceInstanceID);
     Lwm2mTreeNode_SetType(*dest, Lwm2mTreeNodeType_ResourceInstance);
 
-    // Determine buffer size required to read entire resource instance contents
-    valueLength = Lwm2mCore_GetResourceInstanceLength(context, objectID, objectInstanceID, resourceID, resourceInstanceID);
-    if (valueLength < 0)
-    {
-        Lwm2m_Error("ERROR: failed to retrieve instance value from object store: /%d/%d/%d/%d\n", objectID, objectInstanceID, resourceID, resourceInstanceID);
-        result = Lwm2mResult_NotFound;
-        goto error;
-    }
-
-    value = malloc(valueLength);
-    if (value == NULL)
-    {
-        Lwm2m_Error("ERROR: out of memory\n");
-        result = Lwm2mResult_OutOfMemory;
-        goto error;
-    }
-
-    if (Lwm2mCore_GetResourceInstanceValue(context, objectID, objectInstanceID, resourceID, resourceInstanceID, value, valueLength) < 0)
+    if (Lwm2mCore_GetResourceInstanceValue(context, objectID, objectInstanceID, resourceID, resourceInstanceID, &value, &valueLength) < 0)
     {
         Lwm2m_Error("ERROR: Failed to retrieve resource instance from object store\n");
         result = Lwm2mResult_NotFound;
@@ -84,7 +67,6 @@ static Lwm2mResult TreeBuilder_ReadResourceInstanceFromStoreAndCreateTree(Lwm2mT
     }
     result = Lwm2mResult_Success;
 error:
-    free(value);
     return result;
 }
 

--- a/core/src/server/lwm2m_core.h
+++ b/core/src/server/lwm2m_core.h
@@ -58,7 +58,7 @@ void Lwm2mCore_Destroy(Lwm2mContextType * context);
 
 // The following functions are called by other parts of the system to "Operate" on a resource
 int Lwm2mCore_GetResourceInstanceValue(Lwm2mContextType * context, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID, ResourceIDType resourceID,
-                                       ResourceInstanceIDType resourceInstanceID, void * Value, int ValueBufferSize);
+                                       ResourceInstanceIDType resourceInstanceID, const void ** Value, int * ValueBufferSize);
 
 int Lwm2mCore_GetResourceInstanceLength(Lwm2mContextType * context, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID, ResourceIDType resourceID, ResourceInstanceIDType resourceInstanceID);
 int Lwm2mCore_GetResourceInstanceCount(Lwm2mContextType * context, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID, ResourceIDType resourceID);

--- a/core/tests/test_object_store_interface.cc
+++ b/core/tests/test_object_store_interface.cc
@@ -29,8 +29,9 @@ TEST_F(ObjectStoreInterfaceTestSuite, test_WriteAndReadSingleResource)
     Lwm2mCore_CreateObjectInstance(context, 0, 0);
     Lwm2mCore_SetResourceInstanceValue(context, 0, 0, 0, 0, static_cast<const char*>(expected), strlen(expected));
 
-    char buffer[512] = { 0 };
-    int len = Lwm2mCore_GetResourceInstanceValue(context, 0, 0, 0, 0, buffer, sizeof(buffer));
+    const char * buffer;
+    int bufferSize = 0;
+    int len = Lwm2mCore_GetResourceInstanceValue(context, 0, 0, 0, 0, (const void **)&buffer, &bufferSize);
 
     EXPECT_EQ(static_cast<size_t>(len), strlen(buffer) + 1);
     EXPECT_EQ(strlen(expected), strlen(buffer));
@@ -98,8 +99,10 @@ TEST_F(ObjectStoreInterfaceTestSuite, test_WriteAndReadMultipleResources)
     i = 0;
     for(auto it = expected.begin(); it < expected.end(); ++it, ++i)
     {
-        char buffer[512] = { 0 };
-        int len = Lwm2mCore_GetResourceInstanceValue(context, 0, 0, i, 0, buffer, sizeof(buffer));
+        const char * buffer = NULL;
+        int len = 0;
+        Lwm2mCore_GetResourceInstanceValue(context, 0, 0, i, 0, (const void **)&buffer, &len);
+        ASSERT_TRUE(buffer != NULL);
         std::string actual(buffer);
         //std::cout << i << ": expected " << *it << ", actual " << actual << std::endl;
         EXPECT_EQ(static_cast<size_t>(len), actual.length() + 1);
@@ -149,8 +152,11 @@ TEST_F(ObjectStoreInterfaceTestSuite, test_WriteAndReadMultipleResourcesWithSpar
     i = 0;
     for(auto it = expected.begin(); it < expected.end(); ++it, ++i)
     {
-        char buffer[512] = { 0 };
-        int len = Lwm2mCore_GetResourceInstanceValue(context, 0, 0, it->id, 0, buffer, sizeof(buffer));
+        const char * buffer = NULL;
+        int len = 0;
+        Lwm2mCore_GetResourceInstanceValue(context, 0, 0, it->id, 0, (const void **)&buffer, &len);
+        ASSERT_TRUE(buffer != NULL);
+
         std::string actual(buffer);
         //std::cout << i << ": expected " << *it << ", actual " << actual << std::endl;
         EXPECT_EQ(static_cast<size_t>(len), actual.length() + 1);


### PR DESCRIPTION
Remove Lwm2mCore_GetResourceInstanceLength and rework Lwm2mCore_GetResourceInstanceValue in order to support Static API handlers.