### PR TITLE
Fix missing filenames and line numbers with non-info log messages.

### DIFF
--- a/core/src/common/lwm2m_debug.c
+++ b/core/src/common/lwm2m_debug.c
@@ -75,7 +75,7 @@ void Lwm2m_Log(DebugLevel level, const char * fileName, int lineNum, char const 
         {
             fprintf(g_outFile, ANSI_COLOUR_BRIGHT_WHITE " [%s] " ANSI_COLOUR_RESET, logLabels[level]);
 
-            if (level >= DebugLevel_Debug)
+            if (debugLevel >= DebugLevel_Debug)
             {
                 const char * shortFileName = strrchr(fileName, DIR_SLASH);
                 fprintf(g_outFile, ANSI_COLOUR_YELLOW "[%s:%d] " ANSI_COLOUR_RESET, shortFileName ? shortFileName+1 : fileName, lineNum);


### PR DESCRIPTION
This patch fixes an issue where non-info log messages, such as warnings and errors, do not display their source filename and line number when the API is in verbose mode.

Ref: N/A
Signed-off-by: David Antliff <david.antliff@imgtec.com>