### PR TITLE
Double IPC Session Connect timeout to 10 seconds.

### DIFF
--- a/api/src/ipc.h
+++ b/api/src/ipc.h
@@ -71,12 +71,9 @@ extern "C" {
 #define IPC_MSG_CANCEL_OBSERVATION "CancelObserve"
 
 
-
 typedef struct _IPCInfo IPCInfo;
 typedef struct _IPCChannel IPCChannel;
 typedef struct _IPCMessage IPCMessage;
-
-#define IPC_UDP_TIMEOUT (5 * 1000)  /* 5 Secs Timeout */
 
 // Response codes, as specified by daemon
 typedef enum

--- a/api/src/session_common.c
+++ b/api/src/session_common.c
@@ -37,6 +37,8 @@
 #include "xmltree.h"
 #include "lwm2m_xml_serdes.h"
 
+#define SESSION_CONNECT_TIMEOUT (10 * 1000)  // 10 second timeout
+
 /* Notes:
  *  - a Session is considered 'connected' if it has a non-NULL IPCChannel.
  */
@@ -376,7 +378,7 @@ AwaError SessionCommon_ConnectSession(SessionCommon * session)
                     IPCMessage_SetType(connectRequest, IPC_MSGTYPE_REQUEST, IPC_MSGTYPE_CONNECT);
 
                     IPCMessage * connectResponse = NULL;
-                    result = IPC_SendAndReceive(session->IPCChannel, connectRequest, &connectResponse, IPC_UDP_TIMEOUT);
+                    result = IPC_SendAndReceive(session->IPCChannel, connectRequest, &connectResponse, SESSION_CONNECT_TIMEOUT);
 
                     if (result == AwaError_Success)
                     {
@@ -465,7 +467,7 @@ AwaError SessionCommon_DisconnectSession(SessionCommon * session)
                 IPCMessage_SetType(connectRequest, IPC_MSGTYPE_REQUEST, IPC_MSGTYPE_DISCONNECT);
 
                 IPCMessage * connectResponse = NULL;
-                result = IPC_SendAndReceive(session->IPCChannel, connectRequest, &connectResponse, IPC_UDP_TIMEOUT);
+                result = IPC_SendAndReceive(session->IPCChannel, connectRequest, &connectResponse, SESSION_CONNECT_TIMEOUT);
 
                 if (result == AwaError_Success)
                 {


### PR DESCRIPTION
Automated tests show occasional failures due to IPC session connect timeouts at the start of some tests. This may be due to overloading of the test system preventing IPC connection from completing within the 5 seconds provided. Doubling this timeout should reduce the incidence of such failures.

Signed-off-by: David Antliff <david.antliff@imgtec.com>