### PR TITLE
Fix error when attempting to create instance of object 7

### DIFF
--- a/core/src/client/lwm2m_connectivity_object.c
+++ b/core/src/client/lwm2m_connectivity_object.c
@@ -44,23 +44,8 @@
 
 static int Lwm2mConnectivityStatistics_CreateOptionalResourceHandler(void * context, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID, ResourceIDType resourceID)
 {
-    DefinitionRegistry * definitions = Lwm2mCore_GetDefinitions((Lwm2mContextType *)context);
-
-    ResourceDefinition * definition = Definition_LookupResourceDefinition(definitions, objectID, resourceID);
-    if (definition == NULL)
-    {
-        Lwm2m_Error("No definition for object ID %d Resource ID %d\n", objectID, resourceID);
-        goto error;
-    }
-
-    if ((resourceID = Lwm2mCore_CreateOptionalResource(context, objectID, objectInstanceID, resourceID)) == -1)
-    {
-        goto error;
-    }
-
+    // No action
     return 0;
-error:
-    return -1;
 }
 
 static int connectivityStatisticsStartOrReset(void * context, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID, ResourceIDType resourceID, uint8_t * inValueBuffer, int inValueBufferLen)

--- a/core/src/server/lwm2m_server_xml_handlers.c
+++ b/core/src/server/lwm2m_server_xml_handlers.c
@@ -953,7 +953,7 @@ static void xmlif_HandleResponse(IpcCoapRequestContext * requestContext, const c
         }
         else
         {
-            Lwm2m_Warning("Request path is NULL - No CoAP request was sent");
+            Lwm2m_Warning("Request path is NULL - No CoAP request was sent\n");
         }
     }
     else
@@ -1485,7 +1485,7 @@ static int xmlif_AddDefaultsForMissingMandatoryValues(Lwm2mContextType * context
             Lwm2mTreeNode_SetValue(resourceInstance, defaultData, defaultLen);
             Lwm2mTreeNode_AddChild(child, resourceInstance);
 
-            Lwm2m_Error("Added default value for: %d\n", resourceID);
+            Lwm2m_Debug("Added default value for: %d\n", resourceID);
         }
     }
 error:

--- a/tools/tests/gtest/test_tools_common.cc
+++ b/tools/tests/gtest/test_tools_common.cc
@@ -234,6 +234,114 @@ INSTANTIATE_TEST_CASE_P(
            Target { const_cast<char *>("/3"),   56345}
         ));
 
+
+
+class TestToolsCommonWithSession: public TestClientWithSession {};
+
+TEST_F(TestToolsCommonWithSession, Client_GetValue_handles_null_target)
+{
+    // test it doesn't seg-fault:
+    Client_GetValue(session_, NULL, "");
+}
+
+TEST_F(TestToolsCommonWithSession, Client_GetValue_handles_null_arg)
+{
+    // test it doesn't seg-fault:
+    Target t = { const_cast<char *>("/7/0/0"), 0 };
+    Client_GetValue(session_, &t, NULL);
+}
+
+TEST_F(TestToolsCommonWithSession, Client_IsObjectTarget_handles_null_target)
+{
+    // test it doesn't seg-fault:
+    Client_IsObjectTarget(session_, NULL);
+}
+
+TEST_F(TestToolsCommonWithSession, Client_IsObjectInstanceTarget_handles_null_target)
+{
+    // test it doesn't seg-fault:
+    Client_IsObjectInstanceTarget(session_, NULL);
+}
+
+TEST_F(TestToolsCommonWithSession, Client_IsResourceTarget_handles_null_target)
+{
+    // test it doesn't seg-fault:
+    Client_IsResourceTarget(session_, NULL);
+}
+
+TEST_F(TestToolsCommonWithSession, Client_IsResourceInstanceTarget_handles_null_target)
+{
+    // test it doesn't seg-fault:
+    Client_IsResourceInstanceTarget(session_, NULL);
+}
+
+
+class TestToolsCommonWithServerSession: public TestServerWithSession {};
+
+TEST_F(TestToolsCommonWithServerSession, Server_GetValue_handles_null_target)
+{
+    // test it doesn't seg-fault:
+    Server_GetValue(session_, NULL, "");
+}
+
+TEST_F(TestToolsCommonWithServerSession, Server_GetValue_handles_null_arg)
+{
+    // test it doesn't seg-fault:
+    Target t = { const_cast<char *>("/7/0/0"), 0 };
+    Server_GetValue(session_, &t, NULL);
+}
+
+TEST_F(TestToolsCommonWithServerSession, Server_IsObjectTarget_handles_null_target)
+{
+    // test it doesn't seg-fault:
+    Server_IsObjectTarget(session_, NULL);
+}
+
+TEST_F(TestToolsCommonWithServerSession, Server_IsObjectInstanceTarget_handles_null_target)
+{
+    // test it doesn't seg-fault:
+    Server_IsObjectInstanceTarget(session_, NULL);
+}
+
+TEST_F(TestToolsCommonWithServerSession, Server_IsResourceTarget_handles_null_target)
+{
+    // test it doesn't seg-fault:
+    Server_IsResourceTarget(session_, NULL);
+}
+
+TEST_F(TestToolsCommonWithServerSession, Server_IsResourceInstanceTarget_handles_null_target)
+{
+    // test it doesn't seg-fault:
+    Server_IsResourceInstanceTarget(session_, NULL);
+}
+
+
+TEST_F(TestToolsCommon, GetNextTargetResourceInstanceIDFromPath_handles_null_targets)
+{
+    int index = 0;
+    GetNextTargetResourceInstanceIDFromPath(NULL, 1, "/3/0/0", &index);
+}
+
+TEST_F(TestToolsCommon, GetNextTargetResourceInstanceIDFromPath_handles_null_path)
+{
+    Target t1 = { const_cast<char *>("/7/0/0"), 0 };
+    Target * targets[] = { &t1 };
+    int index = 0;
+    GetNextTargetResourceInstanceIDFromPath(targets, 1, NULL, &index);
+}
+
+TEST_F(TestToolsCommon, GetNextTargetResourceInstanceIDFromPath_handles_null_index)
+{
+    Target t1 = { const_cast<char *>("/7/0/0"), 0 };
+    Target * targets[] = { &t1 };
+    GetNextTargetResourceInstanceIDFromPath(targets, 1, "/3/0/0", NULL);
+}
+
+TEST_F(TestToolsCommon, PrintAllObjectDefinitions_handles_null_iterator)
+{
+    PrintAllObjectDefinitions(NULL, false);
+}
+
 } // namespace Awa
 
 

--- a/tools/tools_common.c
+++ b/tools/tools_common.c
@@ -390,41 +390,55 @@ char * Client_GetValue(const AwaClientSession * session, const Target * target, 
 {
     char * value = NULL;
 
-    // Only resources can be set
-    AwaResourceID resourceID = AWA_INVALID_ID;
-    AwaClientSession_PathToIDs(session, target->Path, NULL, NULL, &resourceID);
-    if (resourceID == AWA_INVALID_ID)
+    if (target != NULL)
     {
-        Error("Resource or Resource Instance must be specified: %s\n", arg);
-    }
-    else
-    {
-        const char * valueStr = strchr(arg, '=');
-        if (valueStr == NULL)
+        if (arg != NULL)
         {
-            Error("A value must be specified: %s\n", arg);
-        }
-        else
-        {
-            valueStr++;  // Skip the '=' character
-            int valueLen = strlen(valueStr);
-            if (valueLen == 0)
+            // Only resources can be set
+            AwaResourceID resourceID = AWA_INVALID_ID;
+            AwaClientSession_PathToIDs(session, target->Path, NULL, NULL, &resourceID);
+            if (resourceID == AWA_INVALID_ID)
             {
-                Error("A value must be specified: %s\n", arg);
+                Error("Resource or Resource Instance must be specified: %s\n", arg);
             }
             else
             {
-                value = malloc(sizeof(char) * valueLen + 1);
-                if (value != NULL)
+                const char * valueStr = strchr(arg, '=');
+                if (valueStr == NULL)
                 {
-                    strncpy(value, valueStr, valueLen + 1);  // Add 1 to accommodate the null terminator otherwise strncpy doesn't add one
+                    Error("A value must be specified: %s\n", arg);
                 }
                 else
                 {
-                    Error("Out of memory\n");
+                    valueStr++;  // Skip the '=' character
+                    int valueLen = strlen(valueStr);
+                    if (valueLen == 0)
+                    {
+                        Error("A value must be specified: %s\n", arg);
+                    }
+                    else
+                    {
+                        value = malloc(sizeof(char) * valueLen + 1);
+                        if (value != NULL)
+                        {
+                            strncpy(value, valueStr, valueLen + 1);  // Add 1 to accommodate the null terminator otherwise strncpy doesn't add one
+                        }
+                        else
+                        {
+                            Error("Out of memory\n");
+                        }
+                    }
                 }
             }
         }
+        else
+        {
+            Error("arg is NULL\n");
+        }
+    }
+    else
+    {
+        Error("target is NULL\n");
     }
 
     return value;
@@ -436,9 +450,17 @@ bool Client_IsObjectTarget(const AwaClientSession * session, const Target * targ
     AwaObjectID objectID = AWA_INVALID_ID;
     AwaObjectInstanceID objectInstanceID = AWA_INVALID_ID;
     AwaResourceID resourceID = AWA_INVALID_ID;
-    if (AwaClientSession_PathToIDs(session, target->Path, &objectID, &objectInstanceID, &resourceID) == AwaError_Success)
+
+    if (target != NULL)
     {
-        result = IsIDValid(objectID) && !IsIDValid(objectInstanceID) && !IsIDValid(resourceID) && !IsIDValid(target->ResourceInstanceID);
+        if (AwaClientSession_PathToIDs(session, target->Path, &objectID, &objectInstanceID, &resourceID) == AwaError_Success)
+        {
+            result = IsIDValid(objectID) && !IsIDValid(objectInstanceID) && !IsIDValid(resourceID) && !IsIDValid(target->ResourceInstanceID);
+        }
+    }
+    else
+    {
+        Error("target is NULL\n");
     }
     return result;
 }
@@ -449,9 +471,17 @@ bool Client_IsObjectInstanceTarget(const AwaClientSession * session, const Targe
     AwaObjectID objectID = AWA_INVALID_ID;
     AwaObjectInstanceID objectInstanceID = AWA_INVALID_ID;
     AwaResourceID resourceID = AWA_INVALID_ID;
-    if (AwaClientSession_PathToIDs(session, target->Path, &objectID, &objectInstanceID, &resourceID) == AwaError_Success)
+
+    if (target != NULL)
     {
-        result = IsIDValid(objectID) && IsIDValid(objectInstanceID) && !IsIDValid(resourceID) && !IsIDValid(target->ResourceInstanceID);
+        if (AwaClientSession_PathToIDs(session, target->Path, &objectID, &objectInstanceID, &resourceID) == AwaError_Success)
+        {
+            result = IsIDValid(objectID) && IsIDValid(objectInstanceID) && !IsIDValid(resourceID) && !IsIDValid(target->ResourceInstanceID);
+        }
+    }
+    else
+    {
+        Error("target is NULL\n");
     }
     return result;
 }
@@ -462,9 +492,17 @@ bool Client_IsResourceTarget(const AwaClientSession * session, const Target * ta
     AwaObjectID objectID = AWA_INVALID_ID;
     AwaObjectInstanceID objectInstanceID = AWA_INVALID_ID;
     AwaResourceID resourceID = AWA_INVALID_ID;
-    if (AwaClientSession_PathToIDs(session, target->Path, &objectID, &objectInstanceID, &resourceID) == AwaError_Success)
+
+    if (target != NULL)
     {
-        result = IsIDValid(objectID) && IsIDValid(objectInstanceID) && IsIDValid(resourceID) && !IsIDValid(target->ResourceInstanceID);
+        if (AwaClientSession_PathToIDs(session, target->Path, &objectID, &objectInstanceID, &resourceID) == AwaError_Success)
+        {
+            result = IsIDValid(objectID) && IsIDValid(objectInstanceID) && IsIDValid(resourceID) && !IsIDValid(target->ResourceInstanceID);
+        }
+    }
+    else
+    {
+        Error("target is NULL\n");
     }
     return result;
 }
@@ -475,9 +513,17 @@ bool Client_IsResourceInstanceTarget(const AwaClientSession * session, const Tar
     AwaObjectID objectID = AWA_INVALID_ID;
     AwaObjectInstanceID objectInstanceID = AWA_INVALID_ID;
     AwaResourceID resourceID = AWA_INVALID_ID;
-    if (AwaClientSession_PathToIDs(session, target->Path, &objectID, &objectInstanceID, &resourceID) == AwaError_Success)
+
+    if (target != NULL)
     {
-        result = IsIDValid(objectID) && IsIDValid(objectInstanceID) && IsIDValid(resourceID) && IsIDValid(target->ResourceInstanceID);
+        if (AwaClientSession_PathToIDs(session, target->Path, &objectID, &objectInstanceID, &resourceID) == AwaError_Success)
+        {
+            result = IsIDValid(objectID) && IsIDValid(objectInstanceID) && IsIDValid(resourceID) && IsIDValid(target->ResourceInstanceID);
+        }
+    }
+    else
+    {
+        Error("target is NULL\n");
     }
     return result;
 }
@@ -602,30 +648,38 @@ static char * EncodeOpaque(AwaOpaque * value)
 {
     enum { OPAQUE_DISPLAY_LEN = 32 };
     enum { OPAQUE_BUFFER_LEN = (OPAQUE_DISPLAY_LEN * 3) + 32 }; // 3 bytes per character, plus extra for header
+    char * resourceValue = NULL;
 
-    char * resourceValue = (char *)malloc(OPAQUE_BUFFER_LEN);
-    if (resourceValue != NULL)
+    if (value != NULL)
     {
-        memset(resourceValue, 0, OPAQUE_BUFFER_LEN);
-
-        // Print opaque in hex, but truncate the output and place continuation characters on the end.
-        // cppcheck-suppress redundantCopy
-        snprintf(resourceValue, OPAQUE_BUFFER_LEN, "Opaque (%zu):", value->Size);
-        int i;
-        for (i = 0; i < value->Size; i++)
+        resourceValue = (char *)malloc(OPAQUE_BUFFER_LEN);
+        if (resourceValue != NULL)
         {
-            if ((i <= OPAQUE_DISPLAY_LEN) || (i == value->Size - 1))
+            memset(resourceValue, 0, OPAQUE_BUFFER_LEN);
+
+            // Print opaque in hex, but truncate the output and place continuation characters on the end.
+            // cppcheck-suppress redundantCopy
+            snprintf(resourceValue, OPAQUE_BUFFER_LEN, "Opaque (%zu):", value->Size);
+            int i;
+            for (i = 0; i < value->Size; i++)
             {
-                char hexValue[4] = {0};
-                snprintf(hexValue, 4, "%02X ", ((uint8_t*)value->Data)[i]);
-                strcat(resourceValue, hexValue);
-            }
-            else
-            {
-                strcat(resourceValue, "...");
-                break;
+                if ((i <= OPAQUE_DISPLAY_LEN) || (i == value->Size - 1))
+                {
+                    char hexValue[4] = {0};
+                    snprintf(hexValue, 4, "%02X ", ((uint8_t*)value->Data)[i]);
+                    strcat(resourceValue, hexValue);
+                }
+                else
+                {
+                    strcat(resourceValue, "...");
+                    break;
+                }
             }
         }
+    }
+    else
+    {
+        Error("value is NULL\n");
     }
     return resourceValue;
 }
@@ -1300,41 +1354,55 @@ char * Server_GetValue(const AwaServerSession * session, const Target * target, 
 {
     char * value = NULL;
 
-    // Only resources can be set
-    AwaResourceID resourceID = AWA_INVALID_ID;
-    AwaServerSession_PathToIDs(session, target->Path, NULL, NULL, &resourceID);
-    if (resourceID == AWA_INVALID_ID)
+    if (target != NULL)
     {
-        Error("Resource or Resource Instance must be specified: %s\n", arg);
-    }
-    else
-    {
-        const char * valueStr = strchr(arg, '=');
-        if (valueStr == NULL)
+        if (arg != NULL)
         {
-            Error("A value must be specified: %s\n", arg);
-        }
-        else
-        {
-            valueStr++;  // skip the '='
-            int valueLen = strlen(valueStr);
-            if (valueLen == 0)
+            // Only resources can be set
+            AwaResourceID resourceID = AWA_INVALID_ID;
+            AwaServerSession_PathToIDs(session, target->Path, NULL, NULL, &resourceID);
+            if (resourceID == AWA_INVALID_ID)
             {
-                Error("A value must be specified: %s\n", arg);
+                Error("Resource or Resource Instance must be specified: %s\n", arg);
             }
             else
             {
-                value = malloc(sizeof(char) * valueLen + 1);
-                if (value != NULL)
+                const char * valueStr = strchr(arg, '=');
+                if (valueStr == NULL)
                 {
-                    strncpy(value, valueStr, valueLen + 1);  // note: add 1 to accommodate the null terminator otherwise strncpy doesn't add one
+                    Error("A value must be specified: %s\n", arg);
                 }
                 else
                 {
-                    Error("Out of memory\n");
+                    valueStr++;  // skip the '='
+                    int valueLen = strlen(valueStr);
+                    if (valueLen == 0)
+                    {
+                        Error("A value must be specified: %s\n", arg);
+                    }
+                    else
+                    {
+                        value = malloc(sizeof(char) * valueLen + 1);
+                        if (value != NULL)
+                        {
+                            strncpy(value, valueStr, valueLen + 1);  // note: add 1 to accommodate the null terminator otherwise strncpy doesn't add one
+                        }
+                        else
+                        {
+                            Error("Out of memory\n");
+                        }
+                    }
                 }
             }
         }
+        else
+        {
+            Error("arg is NULL\n");
+        }
+    }
+    else
+    {
+        Error("target is NULL\n");
     }
     return value;
 }
@@ -1345,9 +1413,17 @@ bool Server_IsObjectTarget(const AwaServerSession * session, const Target * targ
     AwaObjectID objectID = AWA_INVALID_ID;
     AwaObjectInstanceID objectInstanceID = AWA_INVALID_ID;
     AwaResourceID resourceID = AWA_INVALID_ID;
-    if (AwaServerSession_PathToIDs(session, target->Path, &objectID, &objectInstanceID, &resourceID) == AwaError_Success)
+
+    if (target != NULL)
     {
-        result = IsIDValid(objectID) && !IsIDValid(objectInstanceID) && !IsIDValid(resourceID) && !IsIDValid(target->ResourceInstanceID);
+        if (AwaServerSession_PathToIDs(session, target->Path, &objectID, &objectInstanceID, &resourceID) == AwaError_Success)
+        {
+            result = IsIDValid(objectID) && !IsIDValid(objectInstanceID) && !IsIDValid(resourceID) && !IsIDValid(target->ResourceInstanceID);
+        }
+    }
+    else
+    {
+        Error("target is NULL\n");
     }
     return result;
 }
@@ -1358,9 +1434,17 @@ bool Server_IsObjectInstanceTarget(const AwaServerSession * session, const Targe
     AwaObjectID objectID = AWA_INVALID_ID;
     AwaObjectInstanceID objectInstanceID = AWA_INVALID_ID;
     AwaResourceID resourceID = AWA_INVALID_ID;
-    if (AwaServerSession_PathToIDs(session, target->Path, &objectID, &objectInstanceID, &resourceID) == AwaError_Success)
+
+    if (target != NULL)
     {
-        result = IsIDValid(objectID) && IsIDValid(objectInstanceID) && !IsIDValid(resourceID) && !IsIDValid(target->ResourceInstanceID);
+        if (AwaServerSession_PathToIDs(session, target->Path, &objectID, &objectInstanceID, &resourceID) == AwaError_Success)
+        {
+            result = IsIDValid(objectID) && IsIDValid(objectInstanceID) && !IsIDValid(resourceID) && !IsIDValid(target->ResourceInstanceID);
+        }
+    }
+    else
+    {
+        Error("target is NULL\n");
     }
     return result;
 }
@@ -1371,9 +1455,17 @@ bool Server_IsResourceTarget(const AwaServerSession * session, const Target * ta
     AwaObjectID objectID = AWA_INVALID_ID;
     AwaObjectInstanceID objectInstanceID = AWA_INVALID_ID;
     AwaResourceID resourceID = AWA_INVALID_ID;
-    if (AwaServerSession_PathToIDs(session, target->Path, &objectID, &objectInstanceID, &resourceID) == AwaError_Success)
+
+    if (target != NULL)
     {
-        result = IsIDValid(objectID) && IsIDValid(objectInstanceID) && IsIDValid(resourceID) && !IsIDValid(target->ResourceInstanceID);
+        if (AwaServerSession_PathToIDs(session, target->Path, &objectID, &objectInstanceID, &resourceID) == AwaError_Success)
+        {
+            result = IsIDValid(objectID) && IsIDValid(objectInstanceID) && IsIDValid(resourceID) && !IsIDValid(target->ResourceInstanceID);
+        }
+    }
+    else
+    {
+        Error("target is NULL\n");
     }
     return result;
 }
@@ -1384,9 +1476,17 @@ bool Server_IsResourceInstanceTarget(const AwaServerSession * session, const Tar
     AwaObjectID objectID = AWA_INVALID_ID;
     AwaObjectInstanceID objectInstanceID = AWA_INVALID_ID;
     AwaResourceID resourceID = AWA_INVALID_ID;
-    if (AwaServerSession_PathToIDs(session, target->Path, &objectID, &objectInstanceID, &resourceID) == AwaError_Success)
+
+    if (target != NULL)
     {
-        result = IsIDValid(objectID) && IsIDValid(objectInstanceID) && IsIDValid(resourceID) && IsIDValid(target->ResourceInstanceID);
+        if (AwaServerSession_PathToIDs(session, target->Path, &objectID, &objectInstanceID, &resourceID) == AwaError_Success)
+        {
+            result = IsIDValid(objectID) && IsIDValid(objectInstanceID) && IsIDValid(resourceID) && IsIDValid(target->ResourceInstanceID);
+        }
+    }
+    else
+    {
+        Error("target is NULL\n");
     }
     return result;
 }
@@ -1394,12 +1494,29 @@ bool Server_IsResourceInstanceTarget(const AwaServerSession * session, const Tar
 int GetNextTargetResourceInstanceIDFromPath(Target ** targets, int numTargets, const char * path, int * index)
 {
     AwaResourceInstanceID resourceInstanceID = AWA_INVALID_ID;
-    for (/* no init */; *index < numTargets; (*index)++)
+    if (targets != NULL)
     {
-        if ((targets[*index] != NULL) && (strcmp(targets[*index]->Path, path) == 0))
+        if (path != NULL)
         {
-            resourceInstanceID = targets[(*index)++]->ResourceInstanceID;
-            break;
+            if (index != NULL)
+            {
+                for (/* no init */; *index < numTargets; (*index)++)
+                {
+                    if ((targets[*index] != NULL) && (strcmp(targets[*index]->Path, path) == 0))
+                    {
+                        resourceInstanceID = targets[(*index)++]->ResourceInstanceID;
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                Error("index is NULL\n");
+            }
+        }
+        else
+        {
+            Error("path is NULL\n");
         }
     }
     return resourceInstanceID;


### PR DESCRIPTION
This patch fixes undefined behaviour when an attempt is made to create an instance of object 7, and then a read attempt is made on /7/0/6. In addition, this also adds tests for null pointers in tools_common functions that can lead to a crash with bad tools syntax (e.g. awa-server-write -c IMG -o=/7/0).

Ref: FLOWDM-522
Signed-off-by: David Antliff <david.antliff@imgtec.com>