### PR TITLE
Editing documentation to differentiate the Awa LightweightM2M product

### DIFF
--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -29,7 +29,7 @@ Awa LightWeightM2M is an implementation of OMA LWM2M written in C. It incorporat
 Awa LightWeightM2M source code is made available by Imagination Technologies Limited under the standard 3-clause BSD license described [here.](https://www.tldrlegal.com/l/bsd3)
 
 ### Contributing to Awa LightWeightM2M.
-Contributions to the Awa project are welcome and there are many ways to help, by submitting bug reports for example, or making feature requests, code changes or documentation edits.  
+Contributions to the Awa LightweigthM2M project are welcome and there are many ways to help, by submitting bug reports for example, or making feature requests, code changes or documentation edits.  
 To ensure that the codebase remains easy to understand, maintain and improve, all contributions should adhere to the [coding style guide](coding_style.md).  
 A comprehensive collection of unit tests is being developed and maintained to ensure that new contributions do not break existing functionality. All code submissions should be accompanied by one or more relevant unit tests, implemented within the existing unit test framework as described in the [*Testing*](developer_guide.md#testing) section below.
 
@@ -48,7 +48,7 @@ The codebase is divided into the following parts:
  
 The Client, Server and Bootstrap server are implemented as Linux processes. Typically these run as *daemons*, detached from a parent console, which may be configured to automatically run when the host starts up. For example, a Linux gateway may automatically start the server so that constrained devices are able to register as soon as the gateway becomes available.  
  
-The API is provided as a linkable library, to be incorporated into a user program. The API has three parts:
+The API is provided as a linkable library, to be incorporated into a user program. It has three parts:
  
  * Client API
  * Static client API
@@ -158,7 +158,7 @@ TODO
 
 ## Testing.
 
-Awa LWM2M was developed alongside a comprehensive test suite, implemented within the Google Test framework. Tests are written in C++ and compile as part of one of several "test runner" applications:
+Awa LightweightM2M was developed alongside a comprehensive test suite, implemented within the Google Test framework. Tests are written in C++ and compile as part of one of several "test runner" applications:
  
  * test_core_runner executes tests related to Client and Server daemon components.
  * test_api_runner executes tests related to Client and Server API components, including top-level tests involving multiple daemons.

--- a/doc/example_app.md
+++ b/doc/example_app.md
@@ -34,7 +34,7 @@ The client-tutorial application makes use of the Awa API to define objects and r
 
 ## Awa LightweightM2M installation.
 
-Firstly, Awa LWM2M must be compiled and installed, using the commands below to build and install Awa LWM2M to the  *./build/install* directory:
+Use the commands below to build and install Awa LightweightM2M to the  *./build/install* directory:
 
 ```
 ~/AwaLWM2M$ make

--- a/doc/userguide.md
+++ b/doc/userguide.md
@@ -584,7 +584,7 @@ Full Awa API reference material is available [here](http://flowm2m.github.io/Awa
 
 ### Connecting to third party servers.
 
-A *how to* guide to connecting to Wakaama bootstrap and Eclipse Leshan servers is available [here](doc/3rdparty.md).
+A '*how to*' guide to connecting to Wakaama bootstrap and Eclipse Leshan servers is available [here](doc/3rdparty.md).
 
 ----
 ----

--- a/doc/userguide.md
+++ b/doc/userguide.md
@@ -253,7 +253,7 @@ $ build/core/src/server/awa_serverd --verbose
 $ build/core/src/client/awa_clientd --endPointName client1 --bootstrap coap://127.0.0.1:15685
 ````
 
-### The Awa_API.
+### The Awa API.
 
 The Awa API provides a way for applications to communicate with the LWM2M client and server daemons via the IPC interface.  
 The client API header file can be found in "include/Awa/client.h".  


### PR DESCRIPTION
Editing documentation to differentiate the Awa LightweightM2M product. We're in the habit of referring to Awa LightweightM2M as Awa LWM2M. LWM2M is an OMA affectation and not part of our product name. Since Awa LIghtweightM2M is an implementation of the OMA spec it needs to be differentiated, not lumped in with everything else. May seem picky - but people won't discover the project if they don't use it's correct name.