### PR TITLE
Fix TLV buffer overflow

### DIFF
--- a/core/src/common/lwm2m_tlv.c
+++ b/core/src/common/lwm2m_tlv.c
@@ -54,6 +54,8 @@
 #define BIT6 (1 << 6)
 #define BIT7 (1 << 7)
 
+#define TLV_MAX_HEADER_SIZE              (6)   // Type + 16 bit Ident + 24 bit Length
+
 /*
  * TLV types
  *
@@ -209,7 +211,7 @@ static int TlvEncodeHeader(uint8_t * buffer, int type, uint16_t identifier, int 
  */
 static int TlvEncodeOpaque(uint8_t * buffer, int bufferLen, int type, int id, uint8_t * value, int len)
 {
-    uint8_t header[5];
+    uint8_t header[TLV_MAX_HEADER_SIZE];
     int headerLen;
 
     if ((buffer == NULL) || (len > 0 && value == NULL))
@@ -802,7 +804,7 @@ static int TlvSerialiseResource(SerdesContext * serdesContext, Lwm2mTreeNode * n
 
     if (IS_MULTIPLE_INSTANCE(definition))
     {
-       uint8_t header[5];
+       uint8_t header[TLV_MAX_HEADER_SIZE];
        int headerLen;
        // Add Mutliple resource instance header
        headerLen = TlvEncodeHeader(&header[0], TLV_TYPE_IDENT_MULTIPLE_RESOURCE, resourceID, resourceLength);

--- a/core/tests/test_tlv.cc
+++ b/core/tests/test_tlv.cc
@@ -721,6 +721,39 @@ TEST_F(TlvTestSuite, test_ident_16bit)
     ASSERT_EQ(0, memcmp(buffer, expected, sizeof(expected)));
 }
 
+TEST_F(TlvTestSuite, test_encode_large_opaque)
+{
+    int valueLen = 0x1ffff;
+    int bufferLen = valueLen + 6;
+    uint8_t * value = (uint8_t*)malloc(valueLen);
+    uint8_t * buffer = (uint8_t*)malloc(bufferLen);
+    int len;
+
+    memset(buffer, 0, bufferLen);
+
+    for (int i = 0; i < valueLen; i++)
+    {
+        value [i] = i % 0xff;
+    }
+
+    len = TlvEncodeOpaque(buffer, bufferLen,  TLV_TYPE_IDENT_OBJECT_INSTANCE, 1024, value, valueLen);
+
+    uint8_t expected[] = { 0x38, 0x04, 0x00, 0x01, 0xff, 0xff };
+    
+    ASSERT_EQ(static_cast<int>(bufferLen), len);
+
+    // check header block
+    ASSERT_EQ(0, memcmp(buffer, expected, sizeof(expected)));
+
+    for (int i = 6; i < len; i++) 
+    {
+        ASSERT_EQ(buffer[i], (i - 6) % 0xff);
+    }
+
+    free(value);
+    free(buffer);
+}
+
 TEST_F(TlvTestSuite, test_multiple_instance_resource)
 {
     int16_t temp = 0x44;


### PR DESCRIPTION
Fix out of bounds memory access picked up by coverity

5 bytes were being allocated for the TLV header, which works in most
cases. But in the case where a 16 bit identifier is used with a
24 bit length the resulting header will be 6 bytes and overflow.

Signed-off-by: Chris Dewbery <Christopher.Dewbery@imgtec.com>