### PR TITLE
Add missing header file so ssizet is defined when building on other p…

### DIFF
--- a/core/src/common/lwm2m_bootstrap_config.c
+++ b/core/src/common/lwm2m_bootstrap_config.c
@@ -23,6 +23,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/types.h>
 
 #include "lwm2m_bootstrap_config.h"
 #include "lwm2m_core.h"


### PR DESCRIPTION
Add missing header file so ssizet is defined when building on other platforms

Signed-off-by: Chris Dewbery <Christopher.Dewbery@imgtec.com>