### PR TITLE
Fix default pmin value as this was preventing notifications on the cl…

### DIFF
--- a/core/src/client/lwm2m_server_object.c
+++ b/core/src/client/lwm2m_server_object.c
@@ -188,6 +188,10 @@ static int Lwm2mServer_ResourceReadHandler(void * context, ObjectIDType objectID
                 *bufferLen = -1;
         }
     }
+    else
+    {
+        *bufferLen = -1;
+    }
     return *bufferLen;
 }
 
@@ -334,7 +338,7 @@ void Lwm2mCore_SetServerUpdateRegistration(Lwm2mContextType * context, int serve
 
 int Lwm2mServerObject_GetDefaultMinimumPeriod(Lwm2mContextType * context, int shortServerID)
 {
-    int64_t defaultMinimumPeriod = -1;
+    int64_t defaultMinimumPeriod = 0;
     Lwm2mServerType * server = GetServerObjectByShortServerID(context, shortServerID);
     if (server != NULL)
     {


### PR DESCRIPTION
Fix default pmin value as this was preventing notifications on the client ipc

The default pmin value was set to -1 in the server object.
The min is used to delay notifications and is treated as unsigned
so -1 results in a very long delay.  This value was being used when
sending notifications via the client IPC, which essentially prevented
any client application from receiving notifications.

I have chosen "0" as the default, which results in no delay.
beware that this may result in the flooding of notifications in the
case where pmin is not configured appropriately. In my opinion
pmin/pmax should have no impact at all for the IPC, but we can
address that issue at another time.

Ref: FLOWDM-686
Signed-off-by: Chris Dewbery <Christopher.Dewbery@imgtec.com>