### PR TITLE
Fixed PUT / POST handling on multiple instance and mandatory resources.

### DIFF
--- a/api/tests/test_client_define_defaults.cc
+++ b/api/tests/test_client_define_defaults.cc
@@ -589,8 +589,7 @@ TEST_F(TestClientDefineDefaultsWithDaemon, AwaClient_get_default_value_from_crea
     AwaClientGetOperation_Free(&getOperation);
 }
 
-// FIXME
-TEST_F(TestClientDefineDefaultsWithDaemon, DISABLED_AwaClient_get_default_value_from_created_custom_object_instance_objectlink_array_resource)
+TEST_F(TestClientDefineDefaultsWithDaemon, AwaClient_get_default_value_from_created_custom_object_instance_objectlink_array_resource)
 {
     //Define our custom object
     AwaClientDefineOperation * defineOperation = AwaClientDefineOperation_New(session_);
@@ -836,8 +835,8 @@ TEST_F(TestClientDefineDefaultsWithDaemon, optional_string_array_resource_has_se
 
     const AwaStringArray * valueArray = NULL;
     EXPECT_EQ(AwaError_Success, AwaClientGetResponse_GetValuesAsStringArrayPointer(getResponse, "/1000/0/0", &valueArray));
-    EXPECT_EQ(1u, AwaStringArray_GetValueCount(valueArray));
-    EXPECT_STREQ("", AwaStringArray_GetValueAsCString(valueArray, 0));
+    EXPECT_EQ(0u, AwaStringArray_GetValueCount(valueArray));
+    //EXPECT_STREQ("", AwaStringArray_GetValueAsCString(valueArray, 0));
 
     AwaClientGetOperation_Free(&getOperation);
 }
@@ -864,8 +863,8 @@ TEST_F(TestClientDefineDefaultsWithDaemon, optional_integer_array_resource_has_s
 
     const AwaIntegerArray * valueArray = NULL;
     EXPECT_EQ(AwaError_Success, AwaClientGetResponse_GetValuesAsIntegerArrayPointer(getResponse, "/1000/0/0", &valueArray));
-    EXPECT_EQ(1u, AwaIntegerArray_GetValueCount(valueArray));
-    EXPECT_EQ(0, AwaIntegerArray_GetValue(valueArray, 0));
+    EXPECT_EQ(0u, AwaIntegerArray_GetValueCount(valueArray));
+    //EXPECT_EQ(0, AwaIntegerArray_GetValue(valueArray, 0));
 
     AwaClientGetOperation_Free(&getOperation);
 }
@@ -892,8 +891,8 @@ TEST_F(TestClientDefineDefaultsWithDaemon, optional_float_array_resource_has_sen
 
     const AwaFloatArray * valueArray = NULL;
     EXPECT_EQ(AwaError_Success, AwaClientGetResponse_GetValuesAsFloatArrayPointer(getResponse, "/1000/0/0", &valueArray));
-    EXPECT_EQ(1u, AwaFloatArray_GetValueCount(valueArray));
-    EXPECT_EQ(0.0f, AwaFloatArray_GetValue(valueArray, 0));
+    EXPECT_EQ(0u, AwaFloatArray_GetValueCount(valueArray));
+    //EXPECT_EQ(0.0f, AwaFloatArray_GetValue(valueArray, 0));
 
     AwaClientGetOperation_Free(&getOperation);
 }
@@ -920,8 +919,8 @@ TEST_F(TestClientDefineDefaultsWithDaemon, optional_boolean_array_resource_has_s
 
     const AwaBooleanArray * valueArray = NULL;
     EXPECT_EQ(AwaError_Success, AwaClientGetResponse_GetValuesAsBooleanArrayPointer(getResponse, "/1000/0/0", &valueArray));
-    EXPECT_EQ(1u, AwaBooleanArray_GetValueCount(valueArray));
-    EXPECT_FALSE(AwaBooleanArray_GetValue(valueArray, 0));
+    EXPECT_EQ(0u, AwaBooleanArray_GetValueCount(valueArray));
+    //EXPECT_FALSE(AwaBooleanArray_GetValue(valueArray, 0));
 
     AwaClientGetOperation_Free(&getOperation);
 }
@@ -948,13 +947,12 @@ TEST_F(TestClientDefineDefaultsWithDaemon, optional_time_array_resource_has_sens
 
     const AwaTimeArray * valueArray = NULL;
     EXPECT_EQ(AwaError_Success, AwaClientGetResponse_GetValuesAsTimeArrayPointer(getResponse, "/1000/0/0", &valueArray));
-    EXPECT_EQ(1u, AwaTimeArray_GetValueCount(valueArray));
-    EXPECT_EQ(0, AwaTimeArray_GetValue(valueArray, 0));
+    EXPECT_EQ(0u, AwaTimeArray_GetValueCount(valueArray));
+    //EXPECT_EQ(0, AwaTimeArray_GetValue(valueArray, 0));
 
     AwaClientGetOperation_Free(&getOperation);
 }
 
-// FIXME:
 TEST_F(TestClientDefineDefaultsWithDaemon, optional_opaque_array_resource_has_sensible_default)
 {
     ObjectDescription object = { 1000, "Object1000", 0, 1, {
@@ -977,10 +975,10 @@ TEST_F(TestClientDefineDefaultsWithDaemon, optional_opaque_array_resource_has_se
 
     const AwaOpaqueArray * valueArray = NULL;
     EXPECT_EQ(AwaError_Success, AwaClientGetResponse_GetValuesAsOpaqueArrayPointer(getResponse, "/1000/0/0", &valueArray));
-    EXPECT_EQ(1u, AwaOpaqueArray_GetValueCount(valueArray));
-    AwaOpaque value = AwaOpaqueArray_GetValue(valueArray, 0);
-    EXPECT_EQ(NULL, value.Data);
-    EXPECT_EQ(0u, value.Size);
+    EXPECT_EQ(0u, AwaOpaqueArray_GetValueCount(valueArray));
+//    AwaOpaque value = AwaOpaqueArray_GetValue(valueArray, 0);
+//    EXPECT_EQ(NULL, value.Data);
+//    EXPECT_EQ(0u, value.Size);
 
     AwaClientGetOperation_Free(&getOperation);
 }
@@ -1007,10 +1005,10 @@ TEST_F(TestClientDefineDefaultsWithDaemon, optional_objectlink_array_resource_ha
 
     const AwaObjectLinkArray * valueArray = NULL;
     EXPECT_EQ(AwaError_Success, AwaClientGetResponse_GetValuesAsObjectLinkArrayPointer(getResponse, "/1000/0/0", &valueArray));
-    EXPECT_EQ(1u, AwaObjectLinkArray_GetValueCount(valueArray));
-    AwaObjectLink value = AwaObjectLinkArray_GetValue(valueArray, 0);
-    EXPECT_EQ(0, value.ObjectID);
-    EXPECT_EQ(0, value.ObjectInstanceID);
+    EXPECT_EQ(0u, AwaObjectLinkArray_GetValueCount(valueArray));
+//    AwaObjectLink value = AwaObjectLinkArray_GetValue(valueArray, 0);
+//    EXPECT_EQ(0, value.ObjectID);
+//    EXPECT_EQ(0, value.ObjectInstanceID);
 
     AwaClientGetOperation_Free(&getOperation);
 }

--- a/api/tests/test_write_operation.cc
+++ b/api/tests/test_write_operation.cc
@@ -228,11 +228,11 @@ TEST_F(TestWriteOperationWithConnectedServerAndClientSession, AwaServerWriteOper
     WaitForClientDefinition(AwaObjectDefinition_GetID(object.GetDefinition()));
 
     //create the object instance on the client
-    AwaClientSetOperation * clientSet = AwaClientSetOperation_New(client_session_);
-    EXPECT_TRUE(clientSet != NULL);
-    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_CreateObjectInstance(clientSet, "/1000/0"));
-    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_Perform(clientSet, defaults::timeout));
-    AwaClientSetOperation_Free(&clientSet);
+    AwaClientSetOperation * setOperation = AwaClientSetOperation_New(client_session_);
+    EXPECT_TRUE(setOperation != NULL);
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_CreateObjectInstance(setOperation, "/1000/0"));
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_Perform(setOperation, defaults::timeout));
+    AwaClientSetOperation_Free(&setOperation);
 
     AwaServerWriteOperation * writeOperation = AwaServerWriteOperation_New(server_session_, AwaWriteMode_Update); ASSERT_TRUE(NULL != writeOperation);
     AwaTime value = 123456789;
@@ -254,17 +254,72 @@ TEST_F(TestWriteOperationWithConnectedServerAndClientSession, AwaServerWriteOper
     WaitForClientDefinition(AwaObjectDefinition_GetID(object.GetDefinition()));
 
     //create the object instance on the client
-    AwaClientSetOperation * clientSet = AwaClientSetOperation_New(client_session_);
-    EXPECT_TRUE(clientSet != NULL);
-    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_CreateObjectInstance(clientSet, "/1000/0"));
-    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_Perform(clientSet, defaults::timeout));
-    AwaClientSetOperation_Free(&clientSet);
+    AwaClientSetOperation * setOperation = AwaClientSetOperation_New(client_session_);
+    EXPECT_TRUE(setOperation != NULL);
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_CreateObjectInstance(setOperation, "/1000/0"));
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_Perform(setOperation, defaults::timeout));
+    AwaClientSetOperation_Free(&setOperation);
 
 
     AwaServerWriteOperation * writeOperation = AwaServerWriteOperation_New(server_session_, AwaWriteMode_Replace); ASSERT_TRUE(NULL != writeOperation);
     AwaInteger value = 123456789;
     EXPECT_EQ(AwaError_Success, AwaServerWriteOperation_AddValueAsInteger(writeOperation, "/1000/0/0", value));
     EXPECT_EQ(AwaError_Success, AwaServerWriteOperation_AddValueAsInteger(writeOperation, "/1000/0/1", value));
+    EXPECT_EQ(AwaError_Success, AwaServerWriteOperation_Perform(writeOperation, global::clientEndpointName, defaults::timeout));
+
+    AwaServerWriteOperation_Free(&writeOperation);
+}
+
+TEST_F(TestWriteOperationWithConnectedServerAndClientSession, AwaServerWriteOperation_Perform_put_on_mandatory_object_instance_should_succeed)
+{
+    ObjectDescription object = { 1000, "Object1000", 1, 1,
+    {
+        ResourceDescription(0, "Resource0", AwaResourceType_Integer, 0, 1, AwaResourceOperations_ReadWrite),
+        ResourceDescription(1, "Resource1", AwaResourceType_Integer, 0, 1, AwaResourceOperations_ReadWrite),
+    }};
+    EXPECT_EQ(AwaError_Success, Define(client_session_, object));
+    EXPECT_EQ(AwaError_Success, Define(server_session_, object));
+
+    WaitForClientDefinition(AwaObjectDefinition_GetID(object.GetDefinition()));
+
+    //create the object instance on the client
+    AwaClientSetOperation * setOperation = AwaClientSetOperation_New(client_session_);
+    EXPECT_TRUE(setOperation != NULL);
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_CreateObjectInstance(setOperation, "/1000/0"));
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_Perform(setOperation, defaults::timeout));
+    AwaClientSetOperation_Free(&setOperation);
+
+    AwaServerWriteOperation * writeOperation = AwaServerWriteOperation_New(server_session_, AwaWriteMode_Replace); ASSERT_TRUE(NULL != writeOperation);
+    AwaInteger value = 123456789;
+    EXPECT_EQ(AwaError_Success, AwaServerWriteOperation_AddValueAsInteger(writeOperation, "/1000/0/0", value));
+    EXPECT_EQ(AwaError_Success, AwaServerWriteOperation_AddValueAsInteger(writeOperation, "/1000/0/1", value));
+    EXPECT_EQ(AwaError_Success, AwaServerWriteOperation_Perform(writeOperation, global::clientEndpointName, defaults::timeout));
+
+    AwaServerWriteOperation_Free(&writeOperation);
+}
+
+TEST_F(TestWriteOperationWithConnectedServerAndClientSession, AwaServerWriteOperation_Perform_put_on_mandatory_resource_should_succeed)
+{
+    ObjectDescription object = { 1000, "Object1000", 0, 1,
+    {
+        ResourceDescription(0, "Resource0", AwaResourceType_Integer, 1, 1, AwaResourceOperations_ReadWrite),
+    }};
+    EXPECT_EQ(AwaError_Success, Define(client_session_, object));
+    EXPECT_EQ(AwaError_Success, Define(server_session_, object));
+
+    WaitForClientDefinition(AwaObjectDefinition_GetID(object.GetDefinition()));
+
+    //create the object instance and mandatory resource on the client
+    AwaClientSetOperation * setOperation = AwaClientSetOperation_New(client_session_);
+    EXPECT_TRUE(setOperation != NULL);
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_CreateObjectInstance(setOperation, "/1000/0"));
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_CreateOptionalResource(setOperation, "/1000/0/0"));
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_Perform(setOperation, defaults::timeout));
+    AwaClientSetOperation_Free(&setOperation);
+
+    AwaServerWriteOperation * writeOperation = AwaServerWriteOperation_New(server_session_, AwaWriteMode_Replace); ASSERT_TRUE(NULL != writeOperation);
+    AwaInteger value = 123456789;
+    EXPECT_EQ(AwaError_Success, AwaServerWriteOperation_AddValueAsInteger(writeOperation, "/1000/0/0", value));
     EXPECT_EQ(AwaError_Success, AwaServerWriteOperation_Perform(writeOperation, global::clientEndpointName, defaults::timeout));
 
     AwaServerWriteOperation_Free(&writeOperation);
@@ -283,11 +338,11 @@ TEST_F(TestWriteOperationWithConnectedServerAndClientSession, AwaServerWriteOper
     WaitForClientDefinition(AwaObjectDefinition_GetID(object.GetDefinition()));
 
     //create the object instance on the client
-    AwaClientSetOperation * clientSet = AwaClientSetOperation_New(client_session_);
-    EXPECT_TRUE(clientSet != NULL);
-    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_CreateObjectInstance(clientSet, "/1000/0"));
-    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_Perform(clientSet, defaults::timeout));
-    AwaClientSetOperation_Free(&clientSet);
+    AwaClientSetOperation * setOperation = AwaClientSetOperation_New(client_session_);
+    EXPECT_TRUE(setOperation != NULL);
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_CreateObjectInstance(setOperation, "/1000/0"));
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_Perform(setOperation, defaults::timeout));
+    AwaClientSetOperation_Free(&setOperation);
 
     AwaServerWriteOperation * writeOperation = AwaServerWriteOperation_New(server_session_, AwaWriteMode_Update); ASSERT_TRUE(NULL != writeOperation);
     AwaInteger value = 123456789;
@@ -353,7 +408,7 @@ TEST_F(TestWriteOperationWithConnectedServerAndClientSession, AwaServerWriteOper
 }
 
 
-TEST_F(TestWriteOperationWithConnectedServerAndClientSession, AwaServerWriteOperation_Perform_put_non_existent_resource_instance_should_fail)
+TEST_F(TestWriteOperationWithConnectedServerAndClientSession, AwaServerWriteOperation_Perform_put_non_existent_resource_should_fail)
 {
     ObjectDescription object = { 1000, "Object1000", 0, 1,
     {
@@ -365,11 +420,11 @@ TEST_F(TestWriteOperationWithConnectedServerAndClientSession, AwaServerWriteOper
     WaitForClientDefinition(AwaObjectDefinition_GetID(object.GetDefinition()));
 
     //create the object instance on the client
-    AwaClientSetOperation * clientSet = AwaClientSetOperation_New(client_session_);
-    EXPECT_TRUE(clientSet != NULL);
-    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_CreateObjectInstance(clientSet, "/1000/0"));
-    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_Perform(clientSet, defaults::timeout));
-    AwaClientSetOperation_Free(&clientSet);
+    AwaClientSetOperation * setOperation = AwaClientSetOperation_New(client_session_);
+    EXPECT_TRUE(setOperation != NULL);
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_CreateObjectInstance(setOperation, "/1000/0"));
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_Perform(setOperation, defaults::timeout));
+    AwaClientSetOperation_Free(&setOperation);
 
     const char * path = "/1000/0/0";
     AwaServerWriteOperation * writeOperation = AwaServerWriteOperation_New(server_session_, AwaWriteMode_Replace); ASSERT_TRUE(NULL != writeOperation);
@@ -386,7 +441,7 @@ TEST_F(TestWriteOperationWithConnectedServerAndClientSession, AwaServerWriteOper
 
     AwaServerWriteOperation_Free(&writeOperation);
 }
-TEST_F(TestWriteOperationWithConnectedServerAndClientSession, AwaServerWriteOperation_Perform_post_non_existent_resource_instance_should_succeed)
+TEST_F(TestWriteOperationWithConnectedServerAndClientSession, AwaServerWriteOperation_Perform_post_non_existent_resource_should_succeed)
 {
     ObjectDescription object = { 1000, "Object1000", 0, 1,
     {
@@ -398,11 +453,11 @@ TEST_F(TestWriteOperationWithConnectedServerAndClientSession, AwaServerWriteOper
     WaitForClientDefinition(AwaObjectDefinition_GetID(object.GetDefinition()));
 
     //create the object instance on the client
-    AwaClientSetOperation * clientSet = AwaClientSetOperation_New(client_session_);
-    EXPECT_TRUE(clientSet != NULL);
-    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_CreateObjectInstance(clientSet, "/1000/0"));
-    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_Perform(clientSet, defaults::timeout));
-    AwaClientSetOperation_Free(&clientSet);
+    AwaClientSetOperation * setOperation = AwaClientSetOperation_New(client_session_);
+    EXPECT_TRUE(setOperation != NULL);
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_CreateObjectInstance(setOperation, "/1000/0"));
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_Perform(setOperation, defaults::timeout));
+    AwaClientSetOperation_Free(&setOperation);
 
     const char * path = "/1000/0/0";
     AwaServerWriteOperation * writeOperation = AwaServerWriteOperation_New(server_session_, AwaWriteMode_Update); ASSERT_TRUE(NULL != writeOperation);
@@ -411,6 +466,119 @@ TEST_F(TestWriteOperationWithConnectedServerAndClientSession, AwaServerWriteOper
     EXPECT_EQ(AwaError_Success, AwaServerWriteOperation_Perform(writeOperation, global::clientEndpointName, defaults::timeout));
 
     AwaServerWriteOperation_Free(&writeOperation);
+}
+
+TEST_F(TestWriteOperationWithConnectedServerAndClientSession, AwaServerWriteOperation_Perform_put_on_multiple_instance_resource_instance_should_replace)
+{
+    ObjectDescription object = { 1000, "Object1000", 0, 1,
+    {
+        ResourceDescription(0, "Resource0", AwaResourceType_IntegerArray, 0, 10, AwaResourceOperations_ReadWrite),
+    }};
+    EXPECT_EQ(AwaError_Success, Define(client_session_, object));
+    EXPECT_EQ(AwaError_Success, Define(server_session_, object));
+
+    WaitForClientDefinition(AwaObjectDefinition_GetID(object.GetDefinition()));
+
+    //create the object instance on the client and set the initial value
+    AwaClientSetOperation * clientSet = AwaClientSetOperation_New(client_session_);
+    EXPECT_TRUE(clientSet != NULL);
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_CreateObjectInstance(clientSet, "/1000/0"));
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_CreateOptionalResource(clientSet, "/1000/0/0"));
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_AddArrayValueAsInteger(clientSet, "/1000/0/0", 0, 12345));
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_Perform(clientSet, defaults::timeout));
+    AwaClientSetOperation_Free(&clientSet);
+    AwaInteger expectedValue = 123456789;
+
+    {
+        AwaServerWriteOperation * writeOperation = AwaServerWriteOperation_New(server_session_, AwaWriteMode_Replace); ASSERT_TRUE(NULL != writeOperation);
+
+        AwaIntegerArray * array = AwaIntegerArray_New();
+        AwaIntegerArray_SetValue(array, 1, expectedValue);
+        EXPECT_EQ(AwaError_Success, AwaServerWriteOperation_AddValueAsIntegerArray(writeOperation, "/1000/0/0", array));
+        EXPECT_EQ(AwaError_Success, AwaServerWriteOperation_Perform(writeOperation, global::clientEndpointName, defaults::timeout));
+        AwaIntegerArray_Free(&array);
+        AwaServerWriteOperation_Free(&writeOperation);
+    }
+
+    // should have replaced the entire array
+
+    AwaClientGetOperation * getOperation = AwaClientGetOperation_New(client_session_);
+    EXPECT_TRUE(getOperation != NULL);
+
+    EXPECT_EQ(AwaError_Success, AwaClientGetOperation_AddPath(getOperation, "/1000/0/0"));
+    EXPECT_EQ(AwaError_Success, AwaClientGetOperation_Perform(getOperation, defaults::timeout));
+
+    const AwaClientGetResponse * getResponse = AwaClientGetOperation_GetResponse(getOperation);
+    EXPECT_TRUE(getResponse != NULL);
+
+    const AwaIntegerArray * array;
+    AwaClientGetResponse_GetValuesAsIntegerArrayPointer(getResponse, "/1000/0/0", &array);
+    EXPECT_TRUE(NULL != array);
+
+    AwaIntegerArrayIterator * iterator = AwaIntegerArray_NewIntegerArrayIterator(array);
+
+    ASSERT_TRUE(AwaIntegerArrayIterator_Next(iterator));
+    EXPECT_EQ(1u, AwaIntegerArrayIterator_GetIndex(iterator));
+    EXPECT_EQ(expectedValue, AwaIntegerArrayIterator_GetValue(iterator));
+
+    EXPECT_FALSE(AwaIntegerArrayIterator_Next(iterator));
+
+    AwaIntegerArrayIterator_Free(&iterator);
+    AwaClientGetOperation_Free(&getOperation);
+}
+
+TEST_F(TestWriteOperationWithConnectedServerAndClientSession, AwaServerWriteOperation_Perform_post_on_multiple_instance_resource_instance_should_update)
+{
+    ObjectDescription object = { 1000, "Object1000", 0, 1,
+    {
+        ResourceDescription(0, "Resource0", AwaResourceType_IntegerArray, 0, 10, AwaResourceOperations_ReadWrite),
+    }};
+    EXPECT_EQ(AwaError_Success, Define(client_session_, object));
+    EXPECT_EQ(AwaError_Success, Define(server_session_, object));
+
+    WaitForClientDefinition(AwaObjectDefinition_GetID(object.GetDefinition()));
+
+    //create the object instance on the client and set the initial value
+    AwaClientSetOperation * clientSet = AwaClientSetOperation_New(client_session_);
+    EXPECT_TRUE(clientSet != NULL);
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_CreateObjectInstance(clientSet, "/1000/0"));
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_CreateOptionalResource(clientSet, "/1000/0/0"));
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_AddArrayValueAsInteger(clientSet, "/1000/0/0", 0, 12345));
+    EXPECT_EQ(AwaError_Success, AwaClientSetOperation_Perform(clientSet, defaults::timeout));
+    AwaClientSetOperation_Free(&clientSet);
+
+    {
+        AwaServerWriteOperation * writeOperation = AwaServerWriteOperation_New(server_session_, AwaWriteMode_Update); ASSERT_TRUE(NULL != writeOperation);
+
+        AwaIntegerArray * array = AwaIntegerArray_New();
+        AwaIntegerArray_SetValue(array, 1, 67890);
+        EXPECT_EQ(AwaError_Success, AwaServerWriteOperation_AddValueAsIntegerArray(writeOperation, "/1000/0/0", array));
+        EXPECT_EQ(AwaError_Success, AwaServerWriteOperation_Perform(writeOperation, global::clientEndpointName, defaults::timeout));
+        AwaServerWriteOperation_Free(&writeOperation);
+        AwaIntegerArray_Free(&array);
+    }
+
+    // A get on the resource should contain both the new and initial value.
+
+    AwaClientGetOperation * getOperation = AwaClientGetOperation_New(client_session_);
+    EXPECT_TRUE(getOperation != NULL);
+
+    EXPECT_EQ(AwaError_Success, AwaClientGetOperation_AddPath(getOperation, "/1000/0/0"));
+    EXPECT_EQ(AwaError_Success, AwaClientGetOperation_Perform(getOperation, defaults::timeout));
+
+    const AwaClientGetResponse * getResponse = AwaClientGetOperation_GetResponse(getOperation);
+    EXPECT_TRUE(getResponse != NULL);
+
+    const AwaIntegerArray * array;
+    AwaClientGetResponse_GetValuesAsIntegerArrayPointer(getResponse, "/1000/0/0", &array);
+    EXPECT_TRUE(NULL != array);
+
+    EXPECT_EQ(2u, AwaIntegerArray_GetValueCount(array));
+
+    EXPECT_EQ(12345, AwaIntegerArray_GetValue(array, 0u));
+    EXPECT_EQ(67890, AwaIntegerArray_GetValue(array, 1u));
+
+    AwaClientGetOperation_Free(&getOperation);
 }
 
 TEST_F(TestWriteOperationWithConnectedSession, AwaServerWriteOperation_Perform_handles_invalid_operation_no_content)

--- a/core/src/client/lwm2m_client_xml_handlers.c
+++ b/core/src/client/lwm2m_client_xml_handlers.c
@@ -1410,7 +1410,7 @@ static int xmlif_HandlerDeleteRequest(RequestInfoType * request, TreeNode conten
         TreeNode responseResourceNode = key.ResourceID != AWA_INVALID_ID? ObjectsTree_FindOrCreateChildNode(responseObjectInstanceNode, "Resource", key.ResourceID) : NULL;
         TreeNode responseLeafNode = responseResourceNode? responseResourceNode : responseObjectInstanceNode? responseObjectInstanceNode : responseObjectNode;
 
-        Lwm2mResult deleteResult = Lwm2mCore_Delete(context, Lwm2mRequestOrigin_Client, key.ObjectID, key.InstanceID, key.ResourceID);
+        Lwm2mResult deleteResult = Lwm2mCore_Delete(context, Lwm2mRequestOrigin_Client, key.ObjectID, key.InstanceID, key.ResourceID, false);
 
         IPC_AddResultTag(responseLeafNode, Lwm2mResult_ToAwaError(deleteResult, AwaError_CannotDelete));
     }

--- a/core/src/client/lwm2m_core.h
+++ b/core/src/client/lwm2m_core.h
@@ -106,7 +106,7 @@ ObjectInstanceIDType Lwm2mCore_GetNextObjectInstanceID(Lwm2mContextType * contex
 ResourceIDType Lwm2mCore_GetNextResourceID(Lwm2mContextType * context, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID, ResourceIDType resourceID);
 ResourceInstanceIDType Lwm2mCore_GetNextResourceInstanceID(Lwm2mContextType * context, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID, ResourceIDType resourceID, ResourceInstanceIDType resourceInstanceID);
 
-Lwm2mResult Lwm2mCore_Delete(Lwm2mContextType * context, Lwm2mRequestOrigin requestOrigin, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID, ResourceIDType resourceID);
+Lwm2mResult Lwm2mCore_Delete(Lwm2mContextType * context, Lwm2mRequestOrigin requestOrigin, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID, ResourceIDType resourceID, bool replace);
 
 int Lwm2mCore_Observe(Lwm2mContextType * context, AddressType * addr, const char * token, int tokenLength, ObjectIDType objectID, ObjectInstanceIDType objectInstanceID,
                       ResourceIDType resourceID, ContentType contentType, Lwm2mNotificationCallback callback, void * ContextData);

--- a/core/src/server/lwm2m_server_xml_handlers.c
+++ b/core/src/server/lwm2m_server_xml_handlers.c
@@ -1489,7 +1489,7 @@ static int xmlif_AddDefaultsForMissingMandatoryValues(Lwm2mContextType * context
                 Lwm2mTreeNode_SetValue(resourceInstance, defaultData, defaultLen);
                 Lwm2mTreeNode_AddChild(child, resourceInstance);
 
-                Lwm2m_Error("Added default value for: %d\n", resourceID);
+                Lwm2m_Debug("Added default value to create request for resource: %d\n", resourceID);
             }
         }
         else

--- a/core/tests/test_tlv.cc
+++ b/core/tests/test_tlv.cc
@@ -761,8 +761,8 @@ TEST_F(TlvTestSuite, test_multiple_instance_resource)
     ASSERT_EQ(0, Definition_RegisterObjectType(Lwm2mCore_GetDefinitions(context), (char*)"Test", 14, 1, 0, &defaultObjectOperationHandlers));
     ASSERT_EQ(0, Lwm2mCore_RegisterResourceType(context, (char*)"Res1", 14, 0, ResourceTypeEnum_TypeInteger, 2, 1, Operations_RW, &defaultResourceOperationHandlers));
     Lwm2mCore_CreateObjectInstance(context, 14, 0);
-    Lwm2mCore_SetResourceInstanceValue(context, 14, 0, 0, 1, &temp2, sizeof(temp2));
     Lwm2mCore_SetResourceInstanceValue(context, 14, 0, 0, 0, &temp, sizeof(temp));
+    Lwm2mCore_SetResourceInstanceValue(context, 14, 0, 0, 1, &temp2, sizeof(temp2));
 
     Lwm2mTreeNode * dest;
     int OIR[] = {14};


### PR DESCRIPTION
Added replace flag to Lwm2mCore_Delete to allow delete on resources in the
case we are doing a PUT on a resource (In all other cases, only deletion on
the object / object instance levels are allowed).

Sensible default allocation no longer adds a resource instance to array
resources (Arrays should be empty by default).
Enabled Objectlink array client define defaults tests.

ref: FLOWDM-636
Signed-off-by: Roland Bewick <roland.bewick@imgtec.com>