### PR TITLE
Fix support for Python tools tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ sudo: false
 language: cpp
 compiler: gcc
 
-install:
-    - if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
-
 addons:
  apt:
   sources:
@@ -15,6 +12,14 @@ addons:
    - cmake-data
    - gcc-5
    - g++-5
+   - python-virtualenv
+
+install:
+    - if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
+    - virtualenv --system-site-packages venv
+    - source venv/bin/activate
+    - pip install nose
+    - pip install lxml
 
 # Travis-CI does not support IPv6 addresses:
 script: make tests TEST_FILTER=*.*:-*.*_handles_IPv6_address*

--- a/Makefile
+++ b/Makefile
@@ -118,9 +118,9 @@ VALGRIND_LOG_OPTIONS:=--xml=yes --xml-file=$(VALGRIND_LOG_DIR)/valgrind.%p.xml -
 .PHONY: valgrind_comprehensive
 valgrind_comprehensive: $(TEST_SRC_BIN) $(TEST_API_BIN) $(TEST_TOOLS_BIN)
 	mkdir -p $(VALGRIND_LOG_DIR)
-	valgrind $(VALGRIND_OPTIONS) --trace-children=yes $(VALGRIND_LOG_OPTIONS) $(TEST_SRC_BIN)   $(TEST_PATHS)
-	valgrind $(VALGRIND_OPTIONS) --trace-children=yes $(VALGRIND_LOG_OPTIONS) $(TEST_API_BIN)   $(TEST_PATHS)
-	valgrind $(VALGRIND_OPTIONS) --trace-children=yes $(VALGRIND_LOG_OPTIONS) $(TEST_TOOLS_BIN) $(TEST_PATHS)
+	valgrind $(VALGRIND_OPTIONS) --trace-children=yes $(VALGRIND_LOG_OPTIONS) $(TEST_SRC_BIN)   $(GTEST_OPTIONS) $(TEST_PATHS)
+	valgrind $(VALGRIND_OPTIONS) --trace-children=yes $(VALGRIND_LOG_OPTIONS) $(TEST_API_BIN)   $(GTEST_OPTIONS) $(TEST_PATHS)
+	valgrind $(VALGRIND_OPTIONS) --trace-children=yes $(VALGRIND_LOG_OPTIONS) $(TEST_TOOLS_BIN) $(GTEST_OPTIONS) $(TEST_PATHS)
 
 .PHONY: cppcheck
 cppcheck:

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -78,4 +78,4 @@ TEST_FILES:= \
 
 .PHONY: tests
 tests:
-	-cd tests && ./run_tests $(TEST_FILES) --with-xunit --xunit-file=tools_tests.xml
+	cd tests && ./run_tests $(TEST_FILES) --with-xunit --xunit-file=tools_tests.xml


### PR DESCRIPTION
This patch fixes the issue where failing to run python tests does not cause build to fail. It also adds the required components to the TravisCI container to run the Python tool tests successfully.

Signed-off-by: David Antliff <david.antliff@imgtec.com>