### PR TITLE
Provide build-time switch to disable JSON support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ enable_testing ()
 # build tests, but disable running by default
 option (BUILD_TESTS "Build tests" ON)
 option (RUN_TESTS "Enable tests" OFF)
+option (WITH_JSON "Enable JSON support" ON)
 # cmdline: cmake -DBUILD_TESTS=ON -DRUN_TESTS=OFF ..
 
 option (ENABLE_GCOV "Enable code coverage check" OFF)

--- a/api/tests-static/CMakeLists.txt
+++ b/api/tests-static/CMakeLists.txt
@@ -23,7 +23,7 @@ set (test_static_api_runner_LIBRARIES
   gtest
   pthread
   awa_static
-  lwm2m_common_static
+  awa_common_static
   Awa_static
   libb64_static
 )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,3 +1,8 @@
+if (WITH_JSON)
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWITH_JSON")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWITH_JSON")
+endif ()
+
 add_subdirectory (src)
 
 if (BUILD_TESTS)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,6 +1,5 @@
 if (WITH_JSON)
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWITH_JSON")
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWITH_JSON")
+  add_definitions (-DWITH_JSON)
 endif ()
 
 add_subdirectory (src)

--- a/core/src/bootstrap/CMakeLists.txt
+++ b/core/src/bootstrap/CMakeLists.txt
@@ -8,7 +8,6 @@ set (awa_bootstrapd_SOURCES
   ${CORE_SRC_DIR}/common/lwm2m_tlv.c
   ${CORE_SRC_DIR}/common/lwm2m_plaintext.c
   ${CORE_SRC_DIR}/common/lwm2m_prettyprint.c
-  ${CORE_SRC_DIR}/common/lwm2m_json.c
   ${CORE_SRC_DIR}/common/lwm2m_opaque.c
   ${CORE_SRC_DIR}/common/lwm2m_tree_builder.c
 )
@@ -17,9 +16,17 @@ set (awa_bootstrapd_INCLUDE_DIRS
   ${CORE_SRC_DIR}
   ${CORE_SRC_DIR}/common
   ${CORE_SRC_DIR}/bootstrap
-  ${LIBB64_INCLUDE_DIR}
-  ${LIBJSMN_INCLUDE_DIR}
 )
+
+if (WITH_JSON)
+  list (APPEND awa_bootstrapd_SOURCES
+    ${CORE_SRC_DIR}/common/lwm2m_json.c
+  )
+  get_property (LIBJSMN_INCLUDE_DIR TARGET libjsmn_static PROPERTY INCLUDE_DIRECTORIES)
+  list (APPEND awa_bootstrapd_INCLUDE_DIRS
+    ${LIBJSMN_INCLUDE_DIR}
+  )  
+endif ()
 
 add_definitions (-DLWM2M_BOOTSTRAP)
 
@@ -30,7 +37,7 @@ endif ()
 
 add_executable (awa_bootstrapd ${awa_bootstrapd_SOURCES})
 target_include_directories (awa_bootstrapd PRIVATE ${awa_bootstrapd_INCLUDE_DIRS})
-target_link_libraries (awa_bootstrapd lwm2m_common_static)
+target_link_libraries (awa_bootstrapd awa_common_static)
 
 if (ENABLE_GCOV_TEST)
   target_link_libraries (awa_bootstrapd gcov)

--- a/core/src/bootstrap/CMakeLists.txt
+++ b/core/src/bootstrap/CMakeLists.txt
@@ -22,10 +22,10 @@ if (WITH_JSON)
   list (APPEND awa_bootstrapd_SOURCES
     ${CORE_SRC_DIR}/common/lwm2m_json.c
   )
-  get_property (LIBJSMN_INCLUDE_DIR TARGET libjsmn_static PROPERTY INCLUDE_DIRECTORIES)
+  # LIBJSMN_INCLUDE_DIR is a global, as it's set by an imported target
   list (APPEND awa_bootstrapd_INCLUDE_DIRS
     ${LIBJSMN_INCLUDE_DIR}
-  )  
+  )
 endif ()
 
 add_definitions (-DLWM2M_BOOTSTRAP)

--- a/core/src/client/CMakeLists.txt
+++ b/core/src/client/CMakeLists.txt
@@ -22,8 +22,8 @@ set (awa_clientd_SOURCES
   ${CORE_SRC_DIR}/common/lwm2m_tree_builder.c
   ${CORE_SRC_DIR}/common/lwm2m_observers.c
   ${CORE_SRC_DIR}/common/lwm2m_ipc.c
-  lwm2m_object_tree.c   
-  
+  lwm2m_object_tree.c
+
   ######################## TODO REMOVE ########################
   # TODO: extract components common to both Core and API
   # FIXME: API_SRC_DIR is not in the cmake cache at the time this is read
@@ -70,10 +70,10 @@ if (WITH_JSON)
   list (APPEND awa_clientd_SOURCES
     ${CORE_SRC_DIR}/common/lwm2m_json.c
   )
-  get_property (LIBJSMN_INCLUDE_DIR TARGET libjsmn_static PROPERTY INCLUDE_DIRECTORIES)
+  # LIBJSMN_INCLUDE_DIR is a global, as it's set by an imported target
   list (APPEND awa_clientd_INCLUDE_DIRS
     ${LIBJSMN_INCLUDE_DIR}
-  )  
+  )
 endif ()
 
 add_definitions (-DLWM2M_CLIENT)

--- a/core/src/client/CMakeLists.txt
+++ b/core/src/client/CMakeLists.txt
@@ -18,7 +18,6 @@ set (awa_clientd_SOURCES
   ${CORE_SRC_DIR}/common/lwm2m_tlv.c
   ${CORE_SRC_DIR}/common/lwm2m_plaintext.c
   ${CORE_SRC_DIR}/common/lwm2m_prettyprint.c
-  ${CORE_SRC_DIR}/common/lwm2m_json.c
   ${CORE_SRC_DIR}/common/lwm2m_opaque.c
   ${CORE_SRC_DIR}/common/lwm2m_tree_builder.c
   ${CORE_SRC_DIR}/common/lwm2m_observers.c
@@ -46,14 +45,12 @@ set (awa_clientd_SOURCES
 # (it is not possible to link with an OBJECT library, so these are not automatic)
 get_property (LIB_XML_INCLUDE_DIR TARGET libxml_static PROPERTY INCLUDE_DIRECTORIES)
 get_property (LIB_B64_INCLUDE_DIR TARGET libb64_static PROPERTY INCLUDE_DIRECTORIES)
-get_property (LIB_JSMN_INCLUDE_DIR TARGET libjsmn_static PROPERTY INCLUDE_DIRECTORIES)
 get_property (LIB_HMAC_INCLUDE_DIR TARGET libhmac_static PROPERTY INCLUDE_DIRECTORIES)
 
 set (awa_clientd_INCLUDE_DIRS
   ${LIB_XML_INCLUDE_DIR}
   ${LIB_B64_INCLUDE_DIR}
   ${LIB_HMAC_INCLUDE_DIR}
-  ${LIBJSMN_INCLUDE_DIR}
 
   ${CORE_SRC_DIR}
   ${CORE_SRC_DIR}/common
@@ -69,6 +66,16 @@ set (awa_clientd_INCLUDE_DIRS
   #############################################################
 )
 
+if (WITH_JSON)
+  list (APPEND awa_clientd_SOURCES
+    ${CORE_SRC_DIR}/common/lwm2m_json.c
+  )
+  get_property (LIBJSMN_INCLUDE_DIR TARGET libjsmn_static PROPERTY INCLUDE_DIRECTORIES)
+  list (APPEND awa_clientd_INCLUDE_DIRS
+    ${LIBJSMN_INCLUDE_DIR}
+  )  
+endif ()
+
 add_definitions (-DLWM2M_CLIENT)
 
 if (ENABLE_GCOV)
@@ -83,7 +90,7 @@ set_property (TARGET awa_static PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 add_executable (awa_clientd lwm2m_client.c)
 target_include_directories (awa_clientd PRIVATE ${awa_clientd_INCLUDE_DIRS})
-target_link_libraries (awa_clientd awa_static lwm2m_common_static libb64_static libhmac_static)
+target_link_libraries (awa_clientd awa_static awa_common_static libb64_static libhmac_static)
 
 if (ENABLE_GCOV)
   target_link_libraries (awa_clientd gcov)

--- a/core/src/common/CMakeLists.txt
+++ b/core/src/common/CMakeLists.txt
@@ -29,13 +29,13 @@ set (awa_common_LIBS
 )
 
 if (WITH_JSON)
-  get_property (LIBJSMN_INCLUDE_DIR TARGET libjsmn_static PROPERTY INCLUDE_DIRECTORIES)
+  # LIBJSMN_INCLUDE_DIR is a global, as it's set by an imported target
   list (APPEND awa_common_INCLUDE_DIRS
     ${LIBJSMN_INCLUDE_DIR}
   )
   list (APPEND awa_common_LIBS
     libjsmn_static
-  )  
+  )
 endif ()
 
 # Virtual library to avoid building .o files twice:

--- a/core/src/common/CMakeLists.txt
+++ b/core/src/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-set (lwm2m_common_SOURCES
+set (awa_common_SOURCES
   lwm2m_list.c
   coap_abstraction_libcoap.c
   lwm2m_debug.c
@@ -17,26 +17,41 @@ set (lwm2m_common_SOURCES
 # path here. the API tests depend on core, which depends on the API.
 set (API_INCLUDE_DIR ../../../api/include CACHE INTERNAL "API_INCLUDE_DIR")
 
-set (lwm2m_common_INCLUDE_DIRS
+set (awa_common_INCLUDE_DIRS
   ${LIBCOAP_INCLUDE_DIR}
-  ${LIBJSMN_INCLUDE_DIR}
   ${API_INCLUDE_DIR}
 )
 
+set (awa_common_LIBS
+  libxml_static
+  libcoap_static
+  libb64_static
+)
+
+if (WITH_JSON)
+  get_property (LIBJSMN_INCLUDE_DIR TARGET libjsmn_static PROPERTY INCLUDE_DIRECTORIES)
+  list (APPEND awa_common_INCLUDE_DIRS
+    ${LIBJSMN_INCLUDE_DIR}
+  )
+  list (APPEND awa_common_LIBS
+    libjsmn_static
+  )  
+endif ()
+
 # Virtual library to avoid building .o files twice:
-#add_library(lwm2m_common_object OBJECT ${lwm2m_common_SOURCES})
-#target_include_directories (lwm2m_common_object PRIVATE ${lwm2m_common_INCLUDE_DIRS})
+#add_library(lwm2m_common_object OBJECT ${awa_common_SOURCES})
+#target_include_directories (lwm2m_common_object PRIVATE ${awa_common_INCLUDE_DIRS})
 #set_property(TARGET lwm2m_common_object PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-#add_library (lwm2m_common_static STATIC $<TARGET_OBJECTS:lwm2m_common_object>)
-add_library (lwm2m_common_static STATIC ${lwm2m_common_SOURCES})
-set_target_properties (lwm2m_common_static PROPERTIES OUTPUT_NAME "lwm2mcommon")
-set_target_properties (lwm2m_common_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
+#add_library (awa_common_static STATIC $<TARGET_OBJECTS:lwm2m_common_object>)
+add_library (awa_common_static STATIC ${awa_common_SOURCES})
+set_target_properties (awa_common_static PROPERTIES OUTPUT_NAME "lwm2mcommon")
+set_target_properties (awa_common_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
 # TODO: remove this line after sorting out the libcoap_static include path
-target_include_directories(lwm2m_common_static PUBLIC ${lwm2m_common_INCLUDE_DIRS})
+target_include_directories(awa_common_static PUBLIC ${awa_common_INCLUDE_DIRS})
 
-# Combine libxml and libcoap into lwm2m_common_static:
-target_link_libraries (lwm2m_common_static libxml_static libcoap_static libjsmn_static libb64_static)
+# Combine libxml and libcoap into awa_common_static:
+target_link_libraries (awa_common_static ${awa_common_LIBS})
 
 # Currently disabled as libxml isn't PIC
 #add_library (lwm2m_common_shared SHARED $<TARGET_OBJECTS:lwm2m_common_object>)

--- a/core/src/common/lwm2m_serdes.c
+++ b/core/src/common/lwm2m_serdes.c
@@ -48,8 +48,10 @@ const static SerdesMapEntry serdesList[] =
         { ContentType_CustomPrettyPrint,         &ppSerDes        },
 
 #ifndef CONTIKI
+#ifdef WITH_JSON
         { ContentType_ApplicationOmaLwm2mJson,   &jsonSerDes      },
-#endif
+#endif // WITH_JSON
+#endif // CONTIKI
         { ContentType_ApplicationOmaLwm2mTLV,    &tlvSerDes       },
         { ContentType_ApplicationPlainText,      &plainTextSerDes },
         { ContentType_ApplicationOctetStream,    &opaqueSerDes    },
@@ -57,8 +59,10 @@ const static SerdesMapEntry serdesList[] =
         // Mapping for old types
         { ContentType_ApplicationOmaLwm2mText,   &plainTextSerDes },
 #ifndef CONTIKI
+#ifdef WITH_JSON
         { ContentType_ApplicationJson,           &jsonSerDes      },
-#endif
+#endif // WITH_JSON
+#endif // CONTIKI
         { ContentType_ApplicationOmaLwm2mOpaque, &opaqueSerDes    },
 };
 #define NUM_SERIALISERS (sizeof(serdesList)/sizeof(SerdesMapEntry))

--- a/core/src/server/CMakeLists.txt
+++ b/core/src/server/CMakeLists.txt
@@ -11,7 +11,6 @@ set (awa_serverd_SOURCES
   ${CORE_SRC_DIR}/common/lwm2m_tlv.c
   ${CORE_SRC_DIR}/common/lwm2m_plaintext.c
   ${CORE_SRC_DIR}/common/lwm2m_prettyprint.c
-  ${CORE_SRC_DIR}/common/lwm2m_json.c
   ${CORE_SRC_DIR}/common/lwm2m_opaque.c
   ${CORE_SRC_DIR}/common/lwm2m_tree_builder.c
   ${CORE_SRC_DIR}/common/lwm2m_ipc.c
@@ -38,12 +37,10 @@ set (awa_serverd_SOURCES
 # (it is not possible to link with an OBJECT library, so these are not automatic)
 get_property (LIB_XML_INCLUDE_DIR TARGET libxml_static PROPERTY INCLUDE_DIRECTORIES)
 get_property (LIB_B64_INCLUDE_DIR TARGET libb64_static PROPERTY INCLUDE_DIRECTORIES)
-get_property (LIB_JSMN_INCLUDE_DIR TARGET libjsmn_static PROPERTY INCLUDE_DIRECTORIES)
 
 set (awa_serverd_INCLUDE_DIRS
   ${LIB_XML_INCLUDE_DIR}
   ${LIB_B64_INCLUDE_DIR}
-  ${LIBJSMN_INCLUDE_DIR}
 
   ${CORE_SRC_DIR}
   ${CORE_SRC_DIR}/common
@@ -58,6 +55,15 @@ set (awa_serverd_INCLUDE_DIRS
   ${CORE_SRC_DIR}/../../api/include
   #############################################################
 )
+
+if (WITH_JSON)
+  list (APPEND awa_serverd_SOURCES
+    ${CORE_SRC_DIR}/common/lwm2m_json.c
+  )
+  get_property (LIBJSMN_INCLUDE_DIR TARGET libjsmn_static PROPERTY INCLUDE_DIRECTORIES)
+  list (APPEND awa_serverd_INCLUDE_DIRS
+    ${LIBJSMN_INCLUDE_DIR})
+endif ()
 
 add_definitions (-DLWM2M_SERVER)
 
@@ -81,7 +87,7 @@ set_target_properties (awa_serverd_shared PROPERTIES OUTPUT_NAME "lwm2mserver")
 
 add_executable (awa_serverd lwm2m_server.c)
 target_include_directories (awa_serverd PRIVATE ${awa_serverd_INCLUDE_DIRS})
-target_link_libraries (awa_serverd awa_serverd_static lwm2m_common_static)
+target_link_libraries (awa_serverd awa_serverd_static awa_common_static)
 
 if (ENABLE_GCOV)
    target_link_libraries (awa_serverd gcov)

--- a/core/src/server/CMakeLists.txt
+++ b/core/src/server/CMakeLists.txt
@@ -14,7 +14,7 @@ set (awa_serverd_SOURCES
   ${CORE_SRC_DIR}/common/lwm2m_opaque.c
   ${CORE_SRC_DIR}/common/lwm2m_tree_builder.c
   ${CORE_SRC_DIR}/common/lwm2m_ipc.c
-  
+
   ######################## TODO REMOVE ########################
   # TODO: extract components common to both Core and API
   # FIXME: API_SRC_DIR is not in the cmake cache at the time this is read
@@ -48,7 +48,7 @@ set (awa_serverd_INCLUDE_DIRS
 
   ######################## TODO REMOVE ########################
   # TODO: extract components common to both Core and API
-  # FIXME: API_INCLUDE_DIR is not in the cmake cache at the time this is read  
+  # FIXME: API_INCLUDE_DIR is not in the cmake cache at the time this is read
   #${API_INCLUDE_DIR}
   #${API_SRC_DIR}
   ${CORE_SRC_DIR}/../../api/src
@@ -60,7 +60,7 @@ if (WITH_JSON)
   list (APPEND awa_serverd_SOURCES
     ${CORE_SRC_DIR}/common/lwm2m_json.c
   )
-  get_property (LIBJSMN_INCLUDE_DIR TARGET libjsmn_static PROPERTY INCLUDE_DIRECTORIES)
+  # LIBJSMN_INCLUDE_DIR is a global, as it's set by an imported target
   list (APPEND awa_serverd_INCLUDE_DIRS
     ${LIBJSMN_INCLUDE_DIR})
 endif ()

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -5,7 +5,6 @@ set (test_core_runner_SOURCES
   test_object_store_interface.cc
   test_template.cc
   test_tlv.cc
-  test_json.cc
   test_definition_registry.cc
   test_plaintext.cc
   test_prettyprint.cc
@@ -30,8 +29,14 @@ set (test_core_runner_LIBRARIES
   pthread
   libcoap_static
   awa_static
-  lwm2m_common_static
+  awa_common_static
 )
+
+if (WITH_JSON)
+  list (APPEND test_core_runner_SOURCES
+    test_json.cc
+  )
+endif ()
 
 set (CMAKE_CXX_FLAGS "-Wall -Werror -g -std=c++11")
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -2,7 +2,10 @@ add_subdirectory (b64)
 add_subdirectory (hmac)
 add_subdirectory (libcoap)
 add_subdirectory (xml)
-add_subdirectory (jsmn)
+
+if (WITH_JSON)
+  add_subdirectory (jsmn)
+endif ()
 
 if (BUILD_TESTS)
   # gtest is CMake-enabled

--- a/lib/jsmn/CMakeLists.txt
+++ b/lib/jsmn/CMakeLists.txt
@@ -18,9 +18,10 @@ ExternalProject_Add(libjsmn
     PATCH_COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt.in ${CMAKE_BINARY_DIR}/libjsmn-src/CMakeLists.txt
 )
 
-# for now use a global variable for this until we find a way of setting the property on the libjsmn_static target
+# target properties are not allowed for imported targets, so for now use a global variable
+# for this until we find a way of setting the property on the libjsmn_static target
 set (LIBJSMN_INCLUDE_DIR ${CMAKE_BINARY_DIR}/libjsmn-src ${CMAKE_BINARY_DIR}/libjsmn-build CACHE INTERNAL "")
 
 add_library(libjsmn_static STATIC IMPORTED GLOBAL)
 set_target_properties(libjsmn_static PROPERTIES IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/libjsmn-build/libjsmn.a")
-#set_target_properties(libjsmn_static PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${LIBJSMN_INCLUDE_DIR})
+


### PR DESCRIPTION
This patch provides a mechanism to omit JSON support (and libjsmn dependency). By default, JSON support is included.

To build without JSON support, set the relevant CMAKE option with:

    make CMAKE_OPTIONS=-DWITH_JSON=OFF

Ref: FLOWDM-693
Signed-off-by: David Antliff <david.antliff@imgtec.com>