### PR TITLE
Add support for AwaStaticClient_RegisterResourceWithPointerArray()

### DIFF
--- a/api/tests-static/test_client.cc
+++ b/api/tests-static/test_client.cc
@@ -625,6 +625,26 @@ TEST_F(TestStaticClientWithServer, AwaStaticClient_WithPointer_Invalid)
     EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_RegisterResourceWithPointer(client_, NULL, 7997,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite, &o, sizeof(o), 0));
 }
 
+TEST_F(TestStaticClientWithServer, AwaStaticClient_WithPointerArray)
+{
+    AWA_OPAQUE(o1, 10);
+    AWA_OPAQUE(o2, 10);
+    AWA_OPAQUE(o3, 10);
+    void * pointers[] = {&o1, &o2, &o3, NULL};
+
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_RegisterObject(client_, "TestObject", 7996, 0, 1)); // valid
+
+    EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_RegisterResourceWithPointerArray(NULL,  "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 3, AwaResourceOperations_ReadWrite, pointers, sizeof(o1)));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_RegisterResourceWithPointerArray(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite,  pointers, 0));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_RegisterResourceWithPointerArray(client_, "TestResource", 7996, 1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite, NULL, sizeof(o1)));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_RegisterResourceWithPointerArray(client_, "TestResource", 300,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite,  pointers, sizeof(o1)));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_RegisterResourceWithPointerArray(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 2, 1, AwaResourceOperations_ReadWrite, pointers, sizeof(o1)));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_RegisterResourceWithPointerArray(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 4, AwaResourceOperations_ReadWrite, pointers, sizeof(o1)));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_RegisterResourceWithPointerArray(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 2, AwaResourceOperations_ReadWrite, pointers, sizeof(o1)));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_RegisterResourceWithPointerArray(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 3, AwaResourceOperations_ReadWrite, pointers, sizeof(o1)));
+}
+
+
 TEST_F(TestStaticClientWithServer, AwaStaticClient_CreateObjectInstance_Resource_Invalid)
 {
     AwaInteger i = 0;

--- a/core/src/common/lwm2m_definition.h
+++ b/core/src/common/lwm2m_definition.h
@@ -101,7 +101,8 @@ struct  _ResourceDefinition
 
     // When using "static" mode, these values are used to
     // determine where to locate the memory for this resource type
-    void * DataPointer;  
+    void * DataPointers;
+    bool IsPointerArray;  
     size_t DataElementSize;
     size_t DataStepSize;
 };


### PR DESCRIPTION
AwaStaticClient_RegisterResourceWithPointerArray allows for an array
of pointers to be used instead of a base pointer + offset. This may
be useful when resources are stored at fixed memory locations.

Signed-off-by: Chris Dewbery <Christopher.Dewbery@imgtec.com>