### PR TITLE
Fixed AwaServerObservation_New not allocating memory for ClientID.

### DIFF
--- a/api/src/observe_operation.c
+++ b/api/src/observe_operation.c
@@ -179,13 +179,24 @@ AwaServerObservation * AwaServerObservation_New(const char * clientID, const cha
             observation->Path = strdup(path);
             if (observation->Path != NULL)
             {
-                observation->Operations = List_New();
-                if (observation->Operations != NULL)
+                observation->ClientID = strdup(clientID);
+                if (observation->ClientID != NULL)
                 {
-                    observation->Callback = (void*)callback;
-                    observation->Context = context;
-                    observation->Session = NULL;
-                    observation->ClientID = clientID;
+                    observation->Operations = List_New();
+                    if (observation->Operations != NULL)
+                    {
+                        observation->Callback = (void*)callback;
+                        observation->Context = context;
+                        observation->Session = NULL;
+                    }
+                    else
+                    {
+                        free((void *)observation->Path);
+                        free((void *)observation->ClientID);
+                        Awa_MemSafeFree(observation);
+                        LogErrorWithEnum(AwaError_OutOfMemory);
+                        observation = NULL;
+                    }
                 }
                 else
                 {
@@ -243,6 +254,7 @@ AwaError AwaServerObservation_Free(AwaServerObservation ** observation)
         }
 
         free((void *)(*observation)->Path);
+        free((void *)(*observation)->ClientID);
         Awa_MemSafeFree(*observation);
         *observation = NULL;
 


### PR DESCRIPTION
If the memory was changed at any time before calling
AwaServerObserveOperation_Perform, the request was sent
with an unintended Client ID.

Signed-off-by: Roland Bewick <roland.bewick@imgtec.com>