### PR TITLE
Disable tmpnam deprecation warning, as current design requires a uniq…

### DIFF
--- a/api/tests-static/test_client.cc
+++ b/api/tests-static/test_client.cc
@@ -545,7 +545,9 @@ TEST_F(TestStaticClient,  AwaStaticClient_Bootstrap_Test)
     serverDaemon.SetCoapPort(serverCoapPort);
     serverDaemon.SetIpcPort(serverIpcPort);
 
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     std::string bootstrapConfigFilename = tmpnam(NULL);
+#pragma GCC diagnostic pop
     BootstrapConfigFile bootstrapConfigFile (bootstrapConfigFilename, serverAddress, serverCoapPort);
     bootstrapServerDaemon.SetConfigFile(bootstrapConfigFile.GetFilename());
 

--- a/api/tests/test_bootstrap.cc
+++ b/api/tests/test_bootstrap.cc
@@ -81,7 +81,9 @@ TEST_F(TestBootstrapServer, bootstrap_with_single_client)
     clientDaemon.SetEndpointName(clientEndpointName);
     clientDaemon.SetBootstrapURI(bootstrapURI);
 
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     std::string bootstrapConfigFilename = tmpnam(NULL);
+#pragma GCC diagnostic pop
     BootstrapConfigFile bootstrapConfigFile (bootstrapConfigFilename, serverAddress, serverCoapPort);
     bootstrapServerDaemon.SetConfigFile(bootstrapConfigFile.GetFilename());
 


### PR DESCRIPTION
…ue filename not file descriptor.

Signed-off-by: David Antliff <david.antliff@imgtec.com>