### PR TITLE
Fix bug in server where creating an object will populate optional resources.

### DIFF
--- a/core/src/server/lwm2m_server_xml_handlers.c
+++ b/core/src/server/lwm2m_server_xml_handlers.c
@@ -1448,6 +1448,10 @@ static int xmlif_AddDefaultsForMissingMandatoryValues(Lwm2mContextType * context
             {
                 continue;  // don't add default values for optional multiple instance resources
             }
+            if (resourceDefinition->MinimumInstances == 0)
+            {
+                continue;  // don't add default values for optional resources
+            }
 
             Lwm2mTreeNode * child = Lwm2mTreeNode_GetFirstChild(node);
             while(child != NULL)

--- a/tools/tests/python/test_awa_server.py
+++ b/tools/tests/python/test_awa_server.py
@@ -386,7 +386,7 @@ class TestServer(tools_common.AwaTest):
         # test that we can't read from a write only resource
         customObjects = (
             CustomObject("Object1001", 1001, False, "single", (
-                    CustomResource("Resource100", 100, "string",  "single", "optional", "w"),
+                    CustomResource("Resource100", 100, "string",  "single", "mandatory", "w"),
             )),
         )
 

--- a/tools/tests/python/test_awa_server_write.py
+++ b/tools/tests/python/test_awa_server_write.py
@@ -182,7 +182,7 @@ class TestWrite(tools_common.AwaTest):
         
         customObjects = (
             tools_common.CustomObject("Object1001", 1001, False, "single", (
-                    tools_common.CustomResource("Resource100", 100, "string",  "single", "optional", "rw"),
+                    tools_common.CustomResource("Resource100", 100, "string",  "single", "mandatory", "rw"),
             )),
         )
         params = tools_common.create_define_command(customObjects)
@@ -202,7 +202,7 @@ class TestWrite(tools_common.AwaTest):
         
         customObjects = (
             tools_common.CustomObject("Object1001", 1001, False, "single", (
-                    tools_common.CustomResource("Resource100", 100, "string",  "single", "optional", "rw"),
+                    tools_common.CustomResource("Resource100", 100, "string",  "single", "mandatory", "rw"),
             )),
         )
         params = tools_common.create_define_command(customObjects)
@@ -237,7 +237,7 @@ class TestWrite(tools_common.AwaTest):
         
         customObjects = (
             tools_common.CustomObject("Object1001", 1001, False, "single", (
-                    tools_common.CustomResource("Resource100", 100, "string",  "single", "optional", "rw"),
+                    tools_common.CustomResource("Resource100", 100, "string",  "single", "mandatory", "rw"),
             )),
         )
         params = tools_common.create_define_command(customObjects)
@@ -261,7 +261,7 @@ class TestWrite(tools_common.AwaTest):
         
         customObjects = (
             tools_common.CustomObject("Object1001", 1001, False, "single", (
-                    tools_common.CustomResource("Resource100", 100, "string",  "single", "optional", "rw"),
+                    tools_common.CustomResource("Resource100", 100, "string",  "single", "mandatory", "rw"),
             )),
         )
         params = tools_common.create_define_command(customObjects)


### PR DESCRIPTION
Fixed a bug in an if statement that causes optional resources to be populated with "sensible default values" in a lwm2m write operation. This also includes a test case that highlights the issue.