### PR TITLE
Update starters_guide.md - typo fixed

### DIFF
--- a/doc/starters_guide.md
+++ b/doc/starters_guide.md
@@ -36,7 +36,7 @@ This will produce the following executable files:
 
 * build/core/src/client/awa_clientd
 * build/core/src/server/awa_serverd
-* build/core/src/bootstrapd/awa_bootstrapd
+* build/core/src/bootstrap/awa_bootstrapd
 
  
 For usage information see the [User guide](userguide.md)


### PR DESCRIPTION
Directory name 'bootstrapd' typo fixed. Now says 'bootstrap'.