### PR TITLE
Fixed xmlif_AddDefaultsForMissingMandatoryValues not returning -1 on error.

### DIFF
--- a/core/src/server/lwm2m_server_xml_handlers.c
+++ b/core/src/server/lwm2m_server_xml_handlers.c
@@ -1417,7 +1417,7 @@ error:
 
 static int xmlif_AddDefaultsForMissingMandatoryValues(Lwm2mContextType * context, Lwm2mTreeNode * node)
 {
-    int result = 0;
+    int result = -1;
     int objectID = 0;
 
     switch(Lwm2mTreeNode_GetType(node))
@@ -1530,6 +1530,7 @@ static int xmlif_AddDefaultsForMissingMandatoryValues(Lwm2mContextType * context
             Lwm2m_Error("Resource definition not found for object ID %d, resource ID %d\n", objectID, resourceID);
         }
     }
+    result = 0;
 error:
     return result;
 }


### PR DESCRIPTION
Added test for creating an Opaque via the server API with an empty
default value (simulating what would be used for provisioning).

Signed-off-by: Roland Bewick <roland.bewick@imgtec.com>