### PR TITLE
Return AwaLWM2MError_Timeout via IPC when a CoAP request timesout

### DIFF
--- a/api/include/awa/error.h
+++ b/api/include/awa/error.h
@@ -103,7 +103,7 @@ typedef enum
     AwaLWM2MError_NotFound,             /**< Indicates a LWM2M 4.04 Not Found error was encountered */
     AwaLWM2MError_MethodNotAllowed,     /**< Indicates a LWM2M 4.05 Not Allowed error was encountered */
     AwaLWM2MError_NotAcceptable,        /**< Indicates a LWM2M 4.06 Not Acceptable error was encountered */
-
+    AwaLWM2MError_Timeout,              /**< Indicates a CoAP 5.04 Gateway timeout error was encountered */
     AwaLWM2MError_LAST                  /**< Reserved value */
 } AwaLWM2MError;
 

--- a/api/src/lwm2m_error.c
+++ b/api/src/lwm2m_error.c
@@ -38,6 +38,7 @@ static const char * ServerErrorStrings[] =
     "AwaLWM2MError_NotFound",
     "AwaLWM2MError_MethodNotAllowed",
     "AwaLWM2MError_NotAcceptable",
+    "AwaLWM2MError_Timeout",
 };
 
 const char * AwaLWM2MError_ToString(AwaLWM2MError error)
@@ -91,6 +92,9 @@ AwaLWM2MError LWM2MError_FromCoapResponseCode(int responseCode)
         break;
     case 405:
         error = AwaLWM2MError_MethodNotAllowed;
+        break;
+    case 504:
+        error = AwaLWM2MError_Timeout;
         break;
     default:
         break;

--- a/api/tests-static/support/static_api_support.h
+++ b/api/tests-static/support/static_api_support.h
@@ -124,7 +124,7 @@ protected:
         sprintf(bootstrapinfo.SecurityInfo.PublicKeyOrIdentity, "[PublicKey]");
         sprintf(bootstrapinfo.SecurityInfo.SecretKey, "[SecretKey]");
 
-        bootstrapinfo.ServerInfo.Lifetime = 30;
+        bootstrapinfo.ServerInfo.Lifetime = 60;
         bootstrapinfo.ServerInfo.DefaultMinPeriod = 1;
         bootstrapinfo.ServerInfo.DefaultMaxPeriod = -1;
         bootstrapinfo.ServerInfo.DisableTimeout = 86400;

--- a/core/src/common/coap_abstraction_libcoap.c
+++ b/core/src/common/coap_abstraction_libcoap.c
@@ -854,7 +854,7 @@ void coap_Process(void)
             if (tid == COAP_INVALID_TID)
             {
                 Lwm2m_Error("Transaction Timed out\n");
-                transaction->Callback(transaction->Context, &transaction->Address, NULL, 503, ContentType_None, NULL, 0);
+                transaction->Callback(transaction->Context, &transaction->Address, transaction->Path, 504, ContentType_None, NULL, 0);
 
                 remove_Transaction(transaction);
             }

--- a/core/src/server/lwm2m_server_xml_handlers.c
+++ b/core/src/server/lwm2m_server_xml_handlers.c
@@ -691,8 +691,8 @@ static TreeNode BuildRegisteredEntityTree(const Lwm2mClientType * client)
     {
         ObjectListEntry * entry = ListEntry(j, ObjectListEntry, list);
 
-        char path[256] = { 0 };
-        if (Path_MakePath(path, 256, entry->ObjectID, entry->InstanceID, AWA_INVALID_ID) == AwaError_Success)
+        char path[MAX_PATH_LENGTH] = { 0 };
+        if (Path_MakePath(path, MAX_PATH_LENGTH, entry->ObjectID, entry->InstanceID, AWA_INVALID_ID) == AwaError_Success)
         {
             printf("Add Object %d, Instance %d\n", entry->ObjectID, entry->InstanceID);
             ObjectsTree_AddPath(objectsTree, path, NULL);
@@ -924,31 +924,49 @@ static void xmlif_HandleResponse(IpcCoapRequestContext * requestContext, const c
         if (responsePath != NULL)
         {
             Lwm2m_Debug("Response path: %s\n", responsePath);
-            char * responsePathWithoutQueryString = strdup(responsePath);
-            char * queryString = strchr(responsePathWithoutQueryString, '?');
-            if (queryString != NULL)
+            char * responsePathWithoutQueryString = malloc(strlen(responsePath) + 1);
+            if (responsePathWithoutQueryString != NULL)
             {
-                queryString[0] = '\0';
-            }
-
-            TreeNode pathNode = NULL;
-            InternalError result = ObjectsTree_FindPathNode(requestContext->ResponseObjectsTree, responsePathWithoutQueryString, &pathNode);
-            if (result == InternalError_Success)
-            {
-                if (AwaResult_IsSuccess(coapResponseCode))
+                if (responsePath[0] == '/')
                 {
-                    successCallback(requestContext, responsePathWithoutQueryString, coapResponseCode, pathNode, responseType, contentType, payload, payloadLen);
+                    strcpy(responsePathWithoutQueryString, responsePath);
+                }
+                else 
+                {
+                    responsePathWithoutQueryString[0] = '/';
+                    strcpy(&responsePathWithoutQueryString[1], responsePath);
+                }
+            
+                char * queryString = strchr(responsePathWithoutQueryString, '?');
+                if (queryString != NULL)
+                {
+                    queryString[0] = '\0';
+                }
+
+                TreeNode pathNode = NULL;
+                InternalError result = ObjectsTree_FindPathNode(requestContext->ResponseObjectsTree, responsePathWithoutQueryString, &pathNode);
+                if (result == InternalError_Success)
+                {
+                    if (AwaResult_IsSuccess(coapResponseCode))
+                    {
+                        successCallback(requestContext, responsePathWithoutQueryString, coapResponseCode, pathNode, responseType, contentType, payload, payloadLen);
+                    }
+                    else
+                    {
+                        IPC_AddServerResultTagToAllLeafNodes(pathNode, AwaError_LWM2MError, LWM2MError_FromCoapResponseCode(coapResponseCode));
+                    }
                 }
                 else
                 {
-                    IPC_AddServerResultTagToAllLeafNodes(pathNode, AwaError_LWM2MError, LWM2MError_FromCoapResponseCode(coapResponseCode));
+                    Lwm2m_Error("Could not find CoAP response path in IPC response: %s\n", responsePathWithoutQueryString);
                 }
+                free(responsePathWithoutQueryString);
             }
             else
             {
-                Lwm2m_Error("Could not find CoAP response path in IPC response: %s\n", responsePathWithoutQueryString);
+                Lwm2m_Error("Failed to allocate memory for response\n");
+                responseCode = AwaResult_OutOfMemory;
             }
-            free(responsePathWithoutQueryString);
         }
         else
         {


### PR DESCRIPTION
When a CoAP transaction times out, the LWM2MError field is now
populated with the AwaLWM2MError_Timeout code like so:

`
<Response>
 <Type>Write</Type>
 <Code>200</Code>
 <Content>
  <Clients>
   <Client>
    <ID>TestIMG1</ID>
    <Objects>
     <Object>
      <ID>7998</ID>
      <ObjectInstance>
       <ID>0</ID>
       <Resource>
        <ID>1</ID>
        <Result>
         <Error>AwaError_LWM2MError</Error>
         <LWM2MError>AwaLWM2MError_Timeout</LWM2MError>
        </Result>
       </Resource>
      </ObjectInstance>
     </Object>
    </Objects>
   </Client>
  </Clients>
 </Content>
</Response>
`
Signed-off-by: Chris Dewbery <Christopher.Dewbery@imgtec.com>