### PR TITLE
Static API changes

### DIFF
--- a/api/examples/CMakeLists.txt
+++ b/api/examples/CMakeLists.txt
@@ -23,7 +23,6 @@ set (Examples
   server-execute-example
   server-execute-arguments-example
   
-  
   # TODO: set-array example uses single values and not an array. Add an example for that too and 
   # rename this set-array to set-array-individual-instances-example
   
@@ -31,17 +30,8 @@ set (Examples
   # TODO: subscribe iterate through changeset example
 )
 
-#if (ENABLE_GCOV)
-#  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 --coverage")
-#  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
-#endif ()
-
 foreach (example ${Examples})
-
-  # disable -Wall warnings for _cmdline.c files
-  set_source_files_properties(${example}_cmdline.c PROPERTIES COMPILE_FLAGS -Wno-all)
-  
-  add_executable (${example} ${example}.c)
+   add_executable (${example} ${example}.c)
   target_include_directories (${example} PRIVATE ${API_INCLUDE_DIR})
   target_link_libraries (${example} Awa_static)
   target_link_libraries (${example} libxml_static)
@@ -51,12 +41,4 @@ foreach (example ${Examples})
   endif ()
 endforeach (example ${Examples})
 
-#TODO should we install the examples?
-#install(TARGETS ${Examples}
-#  RUNTIME DESTINATION /bin
-#)
-
-#TODO
-#if (ENABLE_TEST)
-#  add_subdirectory (tests/gtest)
-#endif ()
+add_subdirectory (tutorials)

--- a/api/examples/tutorials/CMakeLists.txt
+++ b/api/examples/tutorials/CMakeLists.txt
@@ -1,0 +1,21 @@
+set (Tutorials
+  client-tutorial1
+  client-tutorial2
+  server-tutorial
+  static-client-tutorial1
+  static-client-tutorial2
+  static-client-tutorial3
+)
+
+foreach (tutorial ${Tutorials})
+
+  add_executable (${tutorial} ${tutorial}.c)
+  target_include_directories (${tutorial} PRIVATE ${API_INCLUDE_DIR})
+  target_link_libraries (${tutorial} Awa_static)
+  target_link_libraries (${tutorial} awa_static)
+  target_link_libraries (${tutorial} libxml_static)
+
+  if (ENABLE_GCOV)
+    target_link_libraries (${tutorial} gcov)
+  endif ()
+endforeach (tutorial ${Tutorials})

--- a/api/examples/tutorials/static-client-tutorial2.c
+++ b/api/examples/tutorials/static-client-tutorial2.c
@@ -37,11 +37,11 @@ static HeaterObject heater[HEATER_INSTANCES];
 
 static void DefineHeaterObject(AwaStaticClient * awaClient)
 {
-    AwaStaticClient_DefineObject(awaClient, "Heater", 1000, 0, HEATER_INSTANCES);
-    AwaStaticClient_DefineResourceWithPointer(awaClient, "Manufacturer", 1000, 101, AwaResourceType_String, 0, 1, AwaResourceOperations_ReadOnly,
-                                                &heater[0].Manufacturer, sizeof(heater[0].Manufacturer), sizeof(heater[0]));
-    AwaStaticClient_DefineResourceWithPointer(awaClient, "Temperature",  1000, 104, AwaResourceType_Float, 0, 1, AwaResourceOperations_ReadOnly,
-                                                &heater[0].Temperature, sizeof(heater[0].Temperature), sizeof(heater[0]));
+    AwaStaticClient_DefineObject(awaClient, 1000, "Heater", 0, HEATER_INSTANCES);
+    AwaStaticClient_DefineResource(awaClient, 1000, 101, "Manufacturer", AwaResourceType_String, 0, 1, AwaResourceOperations_ReadOnly);
+    AwaStaticClient_SetResourceStorageWithPointer(awaClient, 1000, 101, &heater[0].Manufacturer, sizeof(heater[0].Manufacturer), sizeof(heater[0]));
+    AwaStaticClient_DefineResource(awaClient, 1000, 104, "Temperature",  AwaResourceType_Float,  0, 1, AwaResourceOperations_ReadOnly);
+    AwaStaticClient_SetResourceStorageWithPointer(awaClient, 1000, 104, &heater[0].Temperature, sizeof(heater[0].Temperature), sizeof(heater[0]));
 }
 
 static void SetInitialValues(AwaStaticClient * awaClient)

--- a/api/examples/tutorials/static-client-tutorial3.c
+++ b/api/examples/tutorials/static-client-tutorial3.c
@@ -35,9 +35,10 @@ typedef struct
 
 static HeaterObject heater[HEATER_INSTANCES];
 
+
 AwaResult handler(AwaStaticClient * client, AwaOperation operation, AwaObjectID objectID,
-                       AwaObjectInstanceID objectInstanceID, AwaResourceID resourceID, AwaResourceInstanceID resourceInstanceID,
-                       void ** dataPointer, uint16_t * dataSize, bool * changed)
+                  AwaObjectInstanceID objectInstanceID, AwaResourceID resourceID, AwaResourceInstanceID resourceInstanceID,
+                  void ** dataPointer, size_t * dataSize, bool * changed)
 {
     AwaResult result = AwaResult_InternalError;
 
@@ -129,9 +130,12 @@ AwaResult handler(AwaStaticClient * client, AwaOperation operation, AwaObjectID 
 
 static void DefineHeaterObject(AwaStaticClient * awaClient)
 {
-    AwaStaticClient_DefineObjectWithHandler(awaClient, "Heater", 1000, 0, HEATER_INSTANCES, handler);
-    AwaStaticClient_DefineResourceWithHandler(awaClient, "Manufacturer", 1000, 101, AwaResourceType_String, 0, 1, AwaResourceOperations_ReadWrite, handler);
-    AwaStaticClient_DefineResourceWithHandler(awaClient, "Temperature",  1000, 104, AwaResourceType_Float, 0, 1, AwaResourceOperations_ReadWrite, handler);
+    AwaStaticClient_DefineObject(awaClient, 1000, "Heater", 0, HEATER_INSTANCES);
+    AwaStaticClient_SetObjectOperationHandler(awaClient, 1000, handler);
+    AwaStaticClient_DefineResource(awaClient, 1000, 101, "Manufacturer", AwaResourceType_String, 0, 1, AwaResourceOperations_ReadWrite);
+    AwaStaticClient_SetResourceOperationHandler(awaClient, 1000, 101, handler);
+    AwaStaticClient_DefineResource(awaClient, 1000, 104, "Temperature", AwaResourceType_Float, 0, 1, AwaResourceOperations_ReadWrite);
+    AwaStaticClient_SetResourceOperationHandler(awaClient, 1000, 104, handler);
 }
 
 static void CreateHeaterObject(AwaStaticClient * awaClient)

--- a/api/include/awa/static.h
+++ b/api/include/awa/static.h
@@ -382,6 +382,8 @@ void AwaStaticClient_Free(AwaStaticClient ** client);
  ************************************************************************************************************/
 
 /**
+ * @deprecated Use ::AwaStaticClient_DefineObject followed by ::AwaStaticClient_SetObjectOperationHandler instead.
+ *
  * @brief Define a new custom LWM2M object with a user-specified callback handler
  *        that will be called whenever a LWM2M operation on any instance of the
  *        defined object is performed.
@@ -404,7 +406,8 @@ AwaError AwaStaticClient_DefineObjectWithHandler(AwaStaticClient * client, const
                                                  uint16_t minimumInstances, uint16_t maximumInstances, AwaStaticClientHandler handler);
 
 /**
- * @brief Define a new custom LWM2M object, leaving handling of any instances of the object to the LWM2M Client.
+ * @brief Define a new custom LWM2M object. By default, the LWM2M Client will handle instance operations such as delete and create.
+ *        Use ::AwaStaticClient_SetObjectOperationHandler to override this default behaviour with a specified handler.
  *
  *        In order for an LWM2M server to perform operations on the defined object,
  *        a matching object must be defined on the LWM2M server.
@@ -421,6 +424,18 @@ AwaError AwaStaticClient_DefineObjectWithHandler(AwaStaticClient * client, const
  */
 AwaError AwaStaticClient_DefineObject(AwaStaticClient * client, const char * objectName, AwaObjectID objectID,
                                       uint16_t minimumInstances, uint16_t maximumInstances);
+
+/**
+ * @brief Set the Object Operation handler function, to be called by the LWM2M Client when object instances are created or deleted.
+ *
+ * @param[in] client A pointer to a valid Awa Static Client.
+ * @param[in] objectID An ID that uniquely identifies the object for which the handler will be associated.
+ * @param[in] handler A user-specified callback handler.
+ * @return AwaError_Success on success.
+ * @return AwaError_DefinitionInvalid if @e objectID is invalid.
+ * @return AwaError_StaticClientInvalid if @e client is NULL.
+ */
+AwaError AwaStaticClient_SetObjectOperationHandler(AwaStaticClient * client, AwaObjectID objectID, AwaStaticClientHandler handler);
 
 /**
  * @brief Define a new resource of an existing object with a user-specified callback handler

--- a/api/include/awa/static.h
+++ b/api/include/awa/static.h
@@ -422,7 +422,7 @@ AwaError AwaStaticClient_DefineObjectWithHandler(AwaStaticClient * client, const
  *         @e minimumInstances or @e maximumInstances are invalid.
  * @return AwaError_StaticClientInvalid if @e client is NULL.
  */
-AwaError AwaStaticClient_DefineObject(AwaStaticClient * client, const char * objectName, AwaObjectID objectID,
+AwaError AwaStaticClient_DefineObject(AwaStaticClient * client, AwaObjectID objectID, const char * objectName,
                                       uint16_t minimumInstances, uint16_t maximumInstances);
 
 /**
@@ -459,8 +459,8 @@ AwaError AwaStaticClient_SetObjectOperationHandler(AwaStaticClient * client, Awa
  *         @e minimumInstances or @e maximumInstances are invalid.
  * @return AwaError_StaticClientInvalid if @e client is NULL.
  */
-AwaError AwaStaticClient_DefineResource(AwaStaticClient * client, const char * resourceName,
-                                        AwaObjectID objectID, AwaResourceID resourceID, AwaResourceType resourceType,
+AwaError AwaStaticClient_DefineResource(AwaStaticClient * client, AwaObjectID objectID, AwaResourceID resourceID,
+                                        const char * resourceName, AwaResourceType resourceType,
                                         uint16_t minimumInstances, uint16_t maximumInstances, AwaResourceOperations operations);
 
 /**

--- a/api/tests-static/CMakeLists.txt
+++ b/api/tests-static/CMakeLists.txt
@@ -10,8 +10,11 @@ set (test_static_api_runner_SOURCES
   support/static_api_support.cc
   test_static_api.cc
   test_static_api_with_pointer.cc
+  test_static_api_with_pointer_deprecated.cc
   test_static_api_handlers.cc
+  test_static_api_handlers_deprecated.cc
   test_static_api_get_resource_instance_pointer.cc
+  test_static_api_get_resource_instance_pointer_deprecated.cc
 )
 
 set (test_static_api_runner_INCLUDE_DIRS

--- a/api/tests-static/support/static_api_support.h
+++ b/api/tests-static/support/static_api_support.h
@@ -115,7 +115,7 @@ protected:
 
         std::string serverURI = std::string("coap://127.0.0.1:") + std::to_string(global::serverCoapPort) + "/";
         client_ = AwaStaticClient_New();
-        EXPECT_TRUE(client_ != NULL);
+        ASSERT_TRUE(client_ != NULL);
 
         AwaFactoryBootstrapInfo bootstrapinfo = { 0 };
 

--- a/api/tests-static/test_static_api.cc
+++ b/api/tests-static/test_static_api.cc
@@ -28,7 +28,7 @@
 
 namespace Awa {
 
-class TestStaticClient : public testing::Test {};
+class TestStaticClient : public TestClientBase {};
 
 TEST_F(TestStaticClient, AwaStaticClient_New_Free)
 {

--- a/api/tests-static/test_static_api_get_resource_instance_pointer.cc
+++ b/api/tests-static/test_static_api_get_resource_instance_pointer.cc
@@ -103,13 +103,13 @@ protected:
         TestStaticClientWithServer::SetUp();
         TestGetResourceInstancePointerData data = GetParam();
 
-        EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObject(client_, "TestObject", data.ObjectID, 0, 1));
+        EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObject(client_, data.ObjectID, "TestObject", 0, 1));
 
         switch(data.Type)
         {
             case AwaResourceType_Opaque:
             {
-                //EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithPointer(client_, "Test Resource", data.ObjectID, data.ResourceID, data.Type, 1, 1, AwaResourceOperations_ReadWrite, &opaque_, sizeof(opaque_), 0));
+                //EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithPointer(client_, data.ObjectID, data.ResourceID, "Test Resource", data.Type, 1, 1, AwaResourceOperations_ReadWrite, &opaque_, sizeof(opaque_), 0));
                 ASSERT_TRUE(false);
                 break;
             }
@@ -118,7 +118,7 @@ protected:
                     StaticClientAllocedValue_ = malloc(data.ValueSize);
                     EXPECT_TRUE(StaticClientAllocedValue_ != NULL);
                     memset(StaticClientAllocedValue_, 0, data.ValueSize);
-                    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test Resource", data.ObjectID, data.ResourceID, data.Type, 1, 1, AwaResourceOperations_ReadWrite));
+                    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, data.ObjectID, data.ResourceID, "Test Resource", data.Type, 1, 1, AwaResourceOperations_ReadWrite));
                     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceStorageWithPointer(client_, data.ObjectID, data.ResourceID, StaticClientAllocedValue_, data.ValueSize, 0));
                 }
                 break;

--- a/api/tests-static/test_static_api_get_resource_instance_pointer_deprecated.cc
+++ b/api/tests-static/test_static_api_get_resource_instance_pointer_deprecated.cc
@@ -20,6 +20,8 @@
  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ************************************************************************************************************************/
 
+// NOTE: this file uses deprecated API functions.
+
 #include <pthread.h>
 #include <gtest/gtest.h>
 #include "awa/static.h"
@@ -28,7 +30,7 @@
 
 namespace Awa {
 
-namespace TestStaticClientGetResourceInstancePointerDetail
+namespace TestStaticClientGetResourceInstancePointerDetailDeprecated
 {
 
 static AwaInteger dummyInteger1 = 123456;
@@ -71,9 +73,9 @@ const AwaResourceID TEST_RESOURCE_OPAQUEARRAY = 5;
 const AwaResourceID TEST_RESOURCE_TIMEARRAY = 6;
 const AwaResourceID TEST_RESOURCE_OBJECTLINKARRAY = 7;
 
-} // namespace TestStaticClientGetResourceInstancePointerDetail
+} // namespace TestStaticClientGetResourceInstancePointerDetailDeprecated
 
-struct TestGetResourceInstancePointerData
+struct TestGetResourceInstancePointerDataDeprecated
 {
     AwaObjectID ObjectID;
     AwaObjectInstanceID ObjectInstanceID;
@@ -84,7 +86,7 @@ struct TestGetResourceInstancePointerData
     AwaResourceType Type;
 };
 
-::std::ostream& operator<<(::std::ostream& os, const TestGetResourceInstancePointerData& item)
+::std::ostream& operator<<(::std::ostream& os, const TestGetResourceInstancePointerDataDeprecated& item)
 {
   return os << ", ObjectID " << item.ObjectID
             << ", ObjectInstanceID " << item.ObjectInstanceID
@@ -94,14 +96,14 @@ struct TestGetResourceInstancePointerData
             << ", Type " << item.Type;
 }
 
-class TestStaticClientGetResourceInstancePointer : public TestStaticClientWithServer, public ::testing::WithParamInterface< TestGetResourceInstancePointerData >
+class TestStaticClientGetResourceInstancePointerDeprecated : public TestStaticClientWithServer, public ::testing::WithParamInterface< TestGetResourceInstancePointerDataDeprecated >
 {
 
 protected:
 
     void SetUp() {
         TestStaticClientWithServer::SetUp();
-        TestGetResourceInstancePointerData data = GetParam();
+        TestGetResourceInstancePointerDataDeprecated data = GetParam();
 
         EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObject(client_, "TestObject", data.ObjectID, 0, 1));
 
@@ -118,8 +120,7 @@ protected:
                     StaticClientAllocedValue_ = malloc(data.ValueSize);
                     EXPECT_TRUE(StaticClientAllocedValue_ != NULL);
                     memset(StaticClientAllocedValue_, 0, data.ValueSize);
-                    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test Resource", data.ObjectID, data.ResourceID, data.Type, 1, 1, AwaResourceOperations_ReadWrite));
-                    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceStorageWithPointer(client_, data.ObjectID, data.ResourceID, StaticClientAllocedValue_, data.ValueSize, 0));
+                    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithPointer(client_, "Test Resource", data.ObjectID, data.ResourceID, data.Type, 1, 1, AwaResourceOperations_ReadWrite, StaticClientAllocedValue_, data.ValueSize, 0));
                 }
                 break;
         }
@@ -197,9 +198,9 @@ protected:
 };
 
 
-TEST_P(TestStaticClientGetResourceInstancePointer, TestGetResourceInstancePointer)
+TEST_P(TestStaticClientGetResourceInstancePointerDeprecated, TestGetResourceInstancePointer)
 {
-    TestGetResourceInstancePointerData data = GetParam();
+    TestGetResourceInstancePointerDataDeprecated data = GetParam();
 
     size_t ValueSize = 0;
     memcpy(StaticClientAllocedValue_, data.Value, data.ValueSize);
@@ -284,15 +285,15 @@ TEST_P(TestStaticClientGetResourceInstancePointer, TestGetResourceInstancePointe
 }
 
 INSTANTIATE_TEST_CASE_P(
-        TestStaticClientGetResourceInstancePointer,
-        TestStaticClientGetResourceInstancePointer,
+        TestStaticClientGetResourceInstancePointerDeprecated,
+        TestStaticClientGetResourceInstancePointerDeprecated,
         ::testing::Values(
-          TestGetResourceInstancePointerData { TestStaticClientGetResourceInstancePointerDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, TestStaticClientGetResourceInstancePointerDetail::TEST_RESOURCE_STRING,     TestStaticClientGetResourceInstancePointerDetail::dummyString1, strlen(TestStaticClientGetResourceInstancePointerDetail::dummyString1) + 1, AwaResourceType_String},
-          TestGetResourceInstancePointerData { TestStaticClientGetResourceInstancePointerDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, TestStaticClientGetResourceInstancePointerDetail::TEST_RESOURCE_INTEGER,    &TestStaticClientGetResourceInstancePointerDetail::dummyInteger1, sizeof(AwaInteger), AwaResourceType_Integer },
-          TestGetResourceInstancePointerData { TestStaticClientGetResourceInstancePointerDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, TestStaticClientGetResourceInstancePointerDetail::TEST_RESOURCE_INTEGER,    &TestStaticClientGetResourceInstancePointerDetail::dummyFloat1, sizeof(AwaFloat), AwaResourceType_Float },
-          TestGetResourceInstancePointerData { TestStaticClientGetResourceInstancePointerDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, TestStaticClientGetResourceInstancePointerDetail::TEST_RESOURCE_INTEGER,    &TestStaticClientGetResourceInstancePointerDetail::dummyBoolean1, sizeof(AwaBoolean), AwaResourceType_Boolean },
-          TestGetResourceInstancePointerData { TestStaticClientGetResourceInstancePointerDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, TestStaticClientGetResourceInstancePointerDetail::TEST_RESOURCE_INTEGER,    &TestStaticClientGetResourceInstancePointerDetail::dummyTime1, sizeof(AwaTime), AwaResourceType_Time },
-          TestGetResourceInstancePointerData { TestStaticClientGetResourceInstancePointerDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, TestStaticClientGetResourceInstancePointerDetail::TEST_RESOURCE_OBJECTLINK, &TestStaticClientGetResourceInstancePointerDetail::dummyObjectLink1, sizeof(AwaObjectLink), AwaResourceType_ObjectLink}
+          TestGetResourceInstancePointerDataDeprecated { TestStaticClientGetResourceInstancePointerDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, TestStaticClientGetResourceInstancePointerDetailDeprecated::TEST_RESOURCE_STRING,     TestStaticClientGetResourceInstancePointerDetailDeprecated::dummyString1, strlen(TestStaticClientGetResourceInstancePointerDetailDeprecated::dummyString1) + 1, AwaResourceType_String},
+          TestGetResourceInstancePointerDataDeprecated { TestStaticClientGetResourceInstancePointerDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, TestStaticClientGetResourceInstancePointerDetailDeprecated::TEST_RESOURCE_INTEGER,    &TestStaticClientGetResourceInstancePointerDetailDeprecated::dummyInteger1, sizeof(AwaInteger), AwaResourceType_Integer },
+          TestGetResourceInstancePointerDataDeprecated { TestStaticClientGetResourceInstancePointerDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, TestStaticClientGetResourceInstancePointerDetailDeprecated::TEST_RESOURCE_INTEGER,    &TestStaticClientGetResourceInstancePointerDetailDeprecated::dummyFloat1, sizeof(AwaFloat), AwaResourceType_Float },
+          TestGetResourceInstancePointerDataDeprecated { TestStaticClientGetResourceInstancePointerDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, TestStaticClientGetResourceInstancePointerDetailDeprecated::TEST_RESOURCE_INTEGER,    &TestStaticClientGetResourceInstancePointerDetailDeprecated::dummyBoolean1, sizeof(AwaBoolean), AwaResourceType_Boolean },
+          TestGetResourceInstancePointerDataDeprecated { TestStaticClientGetResourceInstancePointerDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, TestStaticClientGetResourceInstancePointerDetailDeprecated::TEST_RESOURCE_INTEGER,    &TestStaticClientGetResourceInstancePointerDetailDeprecated::dummyTime1, sizeof(AwaTime), AwaResourceType_Time },
+          TestGetResourceInstancePointerDataDeprecated { TestStaticClientGetResourceInstancePointerDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, TestStaticClientGetResourceInstancePointerDetailDeprecated::TEST_RESOURCE_OBJECTLINK, &TestStaticClientGetResourceInstancePointerDetailDeprecated::dummyObjectLink1, sizeof(AwaObjectLink), AwaResourceType_ObjectLink}
         ));
 
 } // namespace Awa

--- a/api/tests-static/test_static_api_get_resource_instance_pointer_deprecated.cc
+++ b/api/tests-static/test_static_api_get_resource_instance_pointer_deprecated.cc
@@ -28,6 +28,10 @@
 #include "awa/server.h"
 #include "support/static_api_support.h"
 
+// reverse the name and objectID to match updated API:
+#define AwaStaticClient_DefineObject(A, B, C, D, E) AwaStaticClient_DefineObject(A, C, B, D, E)
+#define AwaStaticClient_DefineResource(A, B, C, D, E, F, G, H) AwaStaticClient_DefineResource(A, C, D, B, E, F, G, H)
+
 namespace Awa {
 
 namespace TestStaticClientGetResourceInstancePointerDetailDeprecated

--- a/api/tests-static/test_static_api_handlers.cc
+++ b/api/tests-static/test_static_api_handlers.cc
@@ -92,9 +92,9 @@ TEST_F(TestStaticClientHandlerWithServer, AwaStaticClient_Create_and_Write_Opera
 
     callback1 cbHandler(client_, 20);
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetApplicationContext(client_, &cbHandler));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, "TestObject", 9999, 0, 1));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, 9999, "TestObject", 0, 1));
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetObjectOperationHandler(client_, 9999, handler));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 9999, 1, AwaResourceType_Integer, 1, 1, AwaResourceOperations_ReadWrite));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, 9999, 1, "TestResource", AwaResourceType_Integer, 1, 1, AwaResourceOperations_ReadWrite));
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, 9999, 1, handler));
 
     AwaServerListClientsOperation * operation = AwaServerListClientsOperation_New(session_);
@@ -179,9 +179,9 @@ TEST_F(TestStaticClientHandlerWithServer, AwaStaticClient_Create_and_Read_Operat
     callback1 cbHandler(client_, 20);
 
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetApplicationContext(client_, &cbHandler));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, "TestObject", 9999, 0, 1));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, 9999, "TestObject", 0, 1));
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetObjectOperationHandler(client_, 9999, handler));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 9999, 1, AwaResourceType_Integer, 1, 1, AwaResourceOperations_ReadWrite));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, 9999, 1, "TestResource", AwaResourceType_Integer, 1, 1, AwaResourceOperations_ReadWrite));
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, 9999, 1, handler));
 
     EXPECT_EQ(AwaError_Success, AwaStaticClient_CreateObjectInstance(client_, 9999, 0));
@@ -278,9 +278,9 @@ TEST_F(TestStaticClientHandlerWithServer, AwaStaticClient_Create_and_Delete_Oper
     callback1 cbHandler(client_, 20);
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetApplicationContext(client_, &cbHandler));
 
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, "TestObject", 9999, 0, 1));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, 9999, "TestObject", 0, 1));
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetObjectOperationHandler(client_, 9999, handler));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 9999, 1, AwaResourceType_Integer, 0, 1, AwaResourceOperations_ReadWrite));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, 9999, 1, "TestResource", AwaResourceType_Integer, 0, 1, AwaResourceOperations_ReadWrite));
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, 9999, 1, handler));
 
     EXPECT_EQ(AwaError_Success, AwaStaticClient_CreateObjectInstance(client_, 9999, 0));
@@ -373,9 +373,9 @@ TEST_F(TestStaticClientHandlerWithServer, AwaStaticClient_Create_and_Execute_Ope
     callback1 cbHandler(client_, 20);
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetApplicationContext(client_, &cbHandler));
 
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, "TestObject", 9999, 0, 1));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, 9999, "TestObject", 0, 1));
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetObjectOperationHandler(client_, 9999, handler));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 9999, 1, AwaResourceType_None, 1, 1, AwaResourceOperations_Execute));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, 9999, 1, "TestResource", AwaResourceType_None, 1, 1, AwaResourceOperations_Execute));
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, 9999, 1, handler));
 
     EXPECT_EQ(AwaError_Success, AwaStaticClient_CreateObjectInstance(client_, 9999, 0));
@@ -581,16 +581,16 @@ protected:
 
         EXPECT_EQ(AwaError_Success, AwaStaticClient_SetApplicationContext(client_, cbHandler));
 
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, "Test Object Single", writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, 1));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, "Test Object Single", 0, 1));
         EXPECT_EQ(AwaError_Success, AwaStaticClient_SetObjectOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, handler));
 
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test String Resource",      writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_STRING,     AwaResourceType_String,     0, 1, AwaResourceOperations_ReadWrite));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test Integer Resource",     writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_INTEGER,    AwaResourceType_Integer,    0, 1, AwaResourceOperations_ReadWrite));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test Float Resource",       writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_FLOAT,      AwaResourceType_Float,      0, 1, AwaResourceOperations_ReadWrite));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test Boolean Resource",     writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_BOOLEAN,    AwaResourceType_Boolean,    0, 1, AwaResourceOperations_ReadWrite));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test Opaque Resource",      writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_OPAQUE,     AwaResourceType_Opaque,     0, 1, AwaResourceOperations_ReadWrite));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test Time Resource",        writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_TIME,       AwaResourceType_Time,       0, 1, AwaResourceOperations_ReadWrite));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test Object Link Resource", writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_OBJECTLINK, AwaResourceType_ObjectLink, 0, 1, AwaResourceOperations_ReadWrite));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_STRING, "Test String Resource",     AwaResourceType_String,     0, 1, AwaResourceOperations_ReadWrite));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_INTEGER, "Test Integer Resource",    AwaResourceType_Integer,    0, 1, AwaResourceOperations_ReadWrite));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_FLOAT, "Test Float Resource",      AwaResourceType_Float,      0, 1, AwaResourceOperations_ReadWrite));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_BOOLEAN, "Test Boolean Resource",    AwaResourceType_Boolean,    0, 1, AwaResourceOperations_ReadWrite));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_OPAQUE, "Test Opaque Resource",     AwaResourceType_Opaque,     0, 1, AwaResourceOperations_ReadWrite));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_TIME, "Test Time Resource",       AwaResourceType_Time,       0, 1, AwaResourceOperations_ReadWrite));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_OBJECTLINK, "Test Object Link Resource", AwaResourceType_ObjectLink, 0, 1, AwaResourceOperations_ReadWrite));
 
         EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_STRING, handler));
         EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_INTEGER, handler));

--- a/api/tests-static/test_static_api_handlers.cc
+++ b/api/tests-static/test_static_api_handlers.cc
@@ -28,6 +28,25 @@
 
 namespace Awa {
 
+class TestStaticClientHandler : public TestClientBase {};
+
+TEST_F(TestStaticClientHandler, AwaStaticClient_SetResourceOperationHandler_Invalid)
+{
+    auto client = AwaStaticClient_New();
+    ASSERT_TRUE(client != NULL);
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client, 9999, "TestObject", 0, 1));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client, 9999, 1, "TestResource", AwaResourceType_Integer, 1, 1, AwaResourceOperations_ReadWrite));
+
+    EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_SetResourceOperationHandler(NULL, 9999, 1, handler));
+    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceOperationHandler(client, 9999, 1, NULL));
+    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceOperationHandler(client, 9998, 1, handler));
+    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceOperationHandler(client, 9999, 2, handler));
+    EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_SetResourceOperationHandler(NULL,   9998, 2, NULL));
+    EXPECT_EQ(AwaError_Success,             AwaStaticClient_SetResourceOperationHandler(client, 9999, 1, handler));
+
+    AwaStaticClient_Free(&client);
+}
+
 class TestStaticClientHandlerWithServer : public TestStaticClientWithServer {};
 
 TEST_F(TestStaticClientHandlerWithServer, AwaStaticClient_Create_and_Write_Operation_for_Object_and_Resource)
@@ -584,20 +603,20 @@ protected:
         EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, "Test Object Single", 0, 1));
         EXPECT_EQ(AwaError_Success, AwaStaticClient_SetObjectOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, handler));
 
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_STRING, "Test String Resource",     AwaResourceType_String,     0, 1, AwaResourceOperations_ReadWrite));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_INTEGER, "Test Integer Resource",    AwaResourceType_Integer,    0, 1, AwaResourceOperations_ReadWrite));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_FLOAT, "Test Float Resource",      AwaResourceType_Float,      0, 1, AwaResourceOperations_ReadWrite));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_BOOLEAN, "Test Boolean Resource",    AwaResourceType_Boolean,    0, 1, AwaResourceOperations_ReadWrite));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_OPAQUE, "Test Opaque Resource",     AwaResourceType_Opaque,     0, 1, AwaResourceOperations_ReadWrite));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_TIME, "Test Time Resource",       AwaResourceType_Time,       0, 1, AwaResourceOperations_ReadWrite));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_STRING,     "Test String Resource",      AwaResourceType_String,     0, 1, AwaResourceOperations_ReadWrite));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_INTEGER,    "Test Integer Resource",     AwaResourceType_Integer,    0, 1, AwaResourceOperations_ReadWrite));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_FLOAT,      "Test Float Resource",       AwaResourceType_Float,      0, 1, AwaResourceOperations_ReadWrite));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_BOOLEAN,    "Test Boolean Resource",     AwaResourceType_Boolean,    0, 1, AwaResourceOperations_ReadWrite));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_OPAQUE,     "Test Opaque Resource",      AwaResourceType_Opaque,     0, 1, AwaResourceOperations_ReadWrite));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_TIME,       "Test Time Resource",        AwaResourceType_Time,       0, 1, AwaResourceOperations_ReadWrite));
         EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_OBJECTLINK, "Test Object Link Resource", AwaResourceType_ObjectLink, 0, 1, AwaResourceOperations_ReadWrite));
 
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_STRING, handler));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_INTEGER, handler));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_FLOAT, handler));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_BOOLEAN, handler));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_OPAQUE, handler));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_TIME, handler));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_STRING,     handler));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_INTEGER,    handler));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_FLOAT,      handler));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_BOOLEAN,    handler));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_OPAQUE,     handler));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_TIME,       handler));
         EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_OBJECTLINK, handler));
 
         EXPECT_EQ(AwaError_Success, AwaStaticClient_CreateObjectInstance(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0));

--- a/api/tests-static/test_static_api_handlers_deprecated.cc
+++ b/api/tests-static/test_static_api_handlers_deprecated.cc
@@ -28,6 +28,10 @@
 #include "awa/server.h"
 #include "support/static_api_support.h"
 
+// reverse the name and objectID to match updated API:
+#define AwaStaticClient_DefineObject(A, B, C, D, E) AwaStaticClient_DefineObject(A, C, B, D, E)
+#define AwaStaticClient_DefineResource(A, B, C, D, E, F, G, H) AwaStaticClient_DefineResource(A, C, D, B, E, F, G, H)
+
 namespace Awa {
 
 class TestStaticClientHandlerWithServerDeprecated : public TestStaticClientWithServer {};

--- a/api/tests-static/test_static_api_handlers_deprecated.cc
+++ b/api/tests-static/test_static_api_handlers_deprecated.cc
@@ -20,6 +20,8 @@
  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ************************************************************************************************************************/
 
+// NOTE: this file uses deprecated API functions.
+
 #include <pthread.h>
 #include <gtest/gtest.h>
 #include "awa/static.h"
@@ -28,9 +30,9 @@
 
 namespace Awa {
 
-class TestStaticClientHandlerWithServer : public TestStaticClientWithServer {};
+class TestStaticClientHandlerWithServerDeprecated : public TestStaticClientWithServer {};
 
-TEST_F(TestStaticClientHandlerWithServer, AwaStaticClient_Create_and_Write_Operation_for_Object_and_Resource)
+TEST_F(TestStaticClientHandlerWithServerDeprecated, AwaStaticClient_Create_and_Write_Operation_for_Object_and_Resource)
 {
     struct callback1 : public StaticClientCallbackPollCondition
     {
@@ -92,10 +94,8 @@ TEST_F(TestStaticClientHandlerWithServer, AwaStaticClient_Create_and_Write_Opera
 
     callback1 cbHandler(client_, 20);
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetApplicationContext(client_, &cbHandler));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, "TestObject", 9999, 0, 1));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetObjectOperationHandler(client_, 9999, handler));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 9999, 1, AwaResourceType_Integer, 1, 1, AwaResourceOperations_ReadWrite));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, 9999, 1, handler));
+    EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObjectWithHandler(client_, "TestObject", 9999, 0, 1, handler));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithHandler(client_, "TestResource", 9999, 1, AwaResourceType_Integer, 1, 1, AwaResourceOperations_ReadWrite, handler));
 
     AwaServerListClientsOperation * operation = AwaServerListClientsOperation_New(session_);
     EXPECT_TRUE(NULL != operation);
@@ -126,7 +126,7 @@ TEST_F(TestStaticClientHandlerWithServer, AwaStaticClient_Create_and_Write_Opera
     AwaServerWriteOperation_Free(&writeOperation);
 }
 
-TEST_F(TestStaticClientHandlerWithServer, AwaStaticClient_Create_and_Read_Operation_for_Object_and_Resource)
+TEST_F(TestStaticClientHandlerWithServerDeprecated, AwaStaticClient_Create_and_Read_Operation_for_Object_and_Resource)
 {
     struct callback1 : public StaticClientCallbackPollCondition
     {
@@ -179,11 +179,8 @@ TEST_F(TestStaticClientHandlerWithServer, AwaStaticClient_Create_and_Read_Operat
     callback1 cbHandler(client_, 20);
 
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetApplicationContext(client_, &cbHandler));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, "TestObject", 9999, 0, 1));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetObjectOperationHandler(client_, 9999, handler));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 9999, 1, AwaResourceType_Integer, 1, 1, AwaResourceOperations_ReadWrite));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, 9999, 1, handler));
-
+    EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObjectWithHandler(client_, "TestObject", 9999, 0, 1, handler));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithHandler(client_, "TestResource", 9999, 1, AwaResourceType_Integer, 1, 1, AwaResourceOperations_ReadWrite, handler));
     EXPECT_EQ(AwaError_Success, AwaStaticClient_CreateObjectInstance(client_, 9999, 0));
 
     AwaServerListClientsOperation * operation = AwaServerListClientsOperation_New(session_);
@@ -221,7 +218,7 @@ static void * do_delete_operation(void * attr)
     return 0;
 }
 
-TEST_F(TestStaticClientHandlerWithServer, AwaStaticClient_Create_and_Delete_Operation_for_Object_and_Resource)
+TEST_F(TestStaticClientHandlerWithServerDeprecated, AwaStaticClient_Create_and_Delete_Operation_for_Object_and_Resource)
 {
     struct callback1 : public StaticClientCallbackPollCondition
     {
@@ -277,12 +274,8 @@ TEST_F(TestStaticClientHandlerWithServer, AwaStaticClient_Create_and_Delete_Oper
 
     callback1 cbHandler(client_, 20);
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetApplicationContext(client_, &cbHandler));
-
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, "TestObject", 9999, 0, 1));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetObjectOperationHandler(client_, 9999, handler));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 9999, 1, AwaResourceType_Integer, 0, 1, AwaResourceOperations_ReadWrite));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, 9999, 1, handler));
-
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObjectWithHandler(client_, "TestObject", 9999, 0, 1, handler));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithHandler(client_, "TestResource", 9999, 1, AwaResourceType_Integer, 0, 1, AwaResourceOperations_ReadWrite, handler));
     EXPECT_EQ(AwaError_Success, AwaStaticClient_CreateObjectInstance(client_, 9999, 0));
     EXPECT_EQ(AwaError_Success, AwaStaticClient_CreateResource(client_, 9999, 0, 1));
 
@@ -322,7 +315,7 @@ static void * do_execute_operation(void * attr)
     return 0;
 }
 
-TEST_F(TestStaticClientHandlerWithServer, AwaStaticClient_Create_and_Execute_Operation_for_Object_and_Resource)
+TEST_F(TestStaticClientHandlerWithServerDeprecated, AwaStaticClient_Create_and_Execute_Operation_for_Object_and_Resource)
 {
     struct callback1 : public StaticClientCallbackPollCondition
     {
@@ -372,12 +365,8 @@ TEST_F(TestStaticClientHandlerWithServer, AwaStaticClient_Create_and_Execute_Ope
 
     callback1 cbHandler(client_, 20);
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetApplicationContext(client_, &cbHandler));
-
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, "TestObject", 9999, 0, 1));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetObjectOperationHandler(client_, 9999, handler));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 9999, 1, AwaResourceType_None, 1, 1, AwaResourceOperations_Execute));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, 9999, 1, handler));
-
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObjectWithHandler(client_, "TestObject", 9999, 0, 1, handler));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithHandler(client_, "TestResource", 9999, 1, AwaResourceType_None, 1, 1, AwaResourceOperations_Execute, handler));
     EXPECT_EQ(AwaError_Success, AwaStaticClient_CreateObjectInstance(client_, 9999, 0));
 
     AwaServerListClientsOperation * operation = AwaServerListClientsOperation_New(session_);
@@ -409,10 +398,10 @@ TEST_F(TestStaticClientHandlerWithServer, AwaStaticClient_Create_and_Execute_Ope
 }
 
 
-namespace writeDetail
+namespace writeDetailDeprecated
 {
 
-struct TestWriteResource
+struct TestWriteResourceDeprecated
 {
     AwaError ExpectedAddResult;
     AwaError ExpectedProcessResult;
@@ -428,7 +417,7 @@ struct TestWriteResource
     bool UseOperation;
 };
 
-::std::ostream& operator<<(::std::ostream& os, const TestWriteResource& item)
+::std::ostream& operator<<(::std::ostream& os, const TestWriteResourceDeprecated& item)
 {
   return os << "Item: ExpectedAddResult " << item.ExpectedAddResult
             << ", ExpectedProcessResult " << item.ExpectedProcessResult
@@ -487,7 +476,7 @@ const AwaResourceID TEST_RESOURCE_OBJECTLINKARRAY = 7;
 
 typedef AwaResult (*TestHandler)(void * context, AwaOperation operation, AwaObjectID objectID, AwaObjectInstanceID objectInstanceID, AwaResourceID resourceID, AwaResourceInstanceID resourceInstanceID, void ** dataPointer, size_t * dataSize, bool * changed);
 
-struct TestWriteReadStaticResource
+struct TestWriteReadStaticResourceDeprecated
 {
     TestHandler WriteHandler;
     TestHandler ReadHandler;
@@ -505,7 +494,7 @@ struct TestWriteReadStaticResource
     bool TestRead;
 };
 
-::std::ostream& operator<<(::std::ostream& os, const TestWriteReadStaticResource& item)
+::std::ostream& operator<<(::std::ostream& os, const TestWriteReadStaticResourceDeprecated& item)
 {
   return os << "Item: WriteHandler " << item.WriteHandler
             << ", ReadHandler " << item.ReadHandler
@@ -520,7 +509,7 @@ struct TestWriteReadStaticResource
             << ", TestRead " << item.TestRead;
 }
 
-class TestStaticClienthandlerWriteReadValue : public TestStaticClientWithServer, public ::testing::WithParamInterface< TestWriteReadStaticResource >
+class TestStaticClientHandlerWriteReadValueDeprecated : public TestStaticClientWithServer, public ::testing::WithParamInterface< TestWriteReadStaticResourceDeprecated >
 {
 
 protected:
@@ -529,9 +518,9 @@ protected:
     {
     public:
 
-        TestWriteReadStaticResource data;
+        TestWriteReadStaticResourceDeprecated data;
 
-        callback1(AwaStaticClient * StaticClient, int maxCount, TestWriteReadStaticResource data) : StaticClientCallbackPollCondition(StaticClient, maxCount), data(data) {};
+        callback1(AwaStaticClient * StaticClient, int maxCount, TestWriteReadStaticResourceDeprecated data) : StaticClientCallbackPollCondition(StaticClient, maxCount), data(data) {};
 
         AwaResult handler(AwaStaticClient * context, AwaOperation operation, AwaObjectID objectID, AwaObjectInstanceID objectInstanceID, AwaResourceID resourceID, AwaResourceInstanceID resourceInstanceID, void ** dataPointer, size_t * dataSize, bool * changed)
         {
@@ -575,32 +564,20 @@ protected:
 
     void SetUp() {
         TestStaticClientWithServer::SetUp();
-        TestWriteReadStaticResource data = GetParam();
+        TestWriteReadStaticResourceDeprecated data = GetParam();
 
         cbHandler = new callback1(client_, 20, data);
 
         EXPECT_EQ(AwaError_Success, AwaStaticClient_SetApplicationContext(client_, cbHandler));
-
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, "Test Object Single", writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, 1));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetObjectOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, handler));
-
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test String Resource",      writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_STRING,     AwaResourceType_String,     0, 1, AwaResourceOperations_ReadWrite));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test Integer Resource",     writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_INTEGER,    AwaResourceType_Integer,    0, 1, AwaResourceOperations_ReadWrite));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test Float Resource",       writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_FLOAT,      AwaResourceType_Float,      0, 1, AwaResourceOperations_ReadWrite));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test Boolean Resource",     writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_BOOLEAN,    AwaResourceType_Boolean,    0, 1, AwaResourceOperations_ReadWrite));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test Opaque Resource",      writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_OPAQUE,     AwaResourceType_Opaque,     0, 1, AwaResourceOperations_ReadWrite));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test Time Resource",        writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_TIME,       AwaResourceType_Time,       0, 1, AwaResourceOperations_ReadWrite));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test Object Link Resource", writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_OBJECTLINK, AwaResourceType_ObjectLink, 0, 1, AwaResourceOperations_ReadWrite));
-
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_STRING, handler));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_INTEGER, handler));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_FLOAT, handler));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_BOOLEAN, handler));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_OPAQUE, handler));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_TIME, handler));
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceOperationHandler(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, writeDetail::TEST_RESOURCE_OBJECTLINK, handler));
-
-        EXPECT_EQ(AwaError_Success, AwaStaticClient_CreateObjectInstance(client_, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObjectWithHandler(client_, "Test Object Single", writeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, 1, handler));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithHandler(client_, "Test String Resource",      writeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, writeDetailDeprecated::TEST_RESOURCE_STRING,     AwaResourceType_String,     0, 1, AwaResourceOperations_ReadWrite, handler));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithHandler(client_, "Test Integer Resource",     writeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, writeDetailDeprecated::TEST_RESOURCE_INTEGER,    AwaResourceType_Integer,    0, 1, AwaResourceOperations_ReadWrite, handler));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithHandler(client_, "Test Float Resource",       writeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, writeDetailDeprecated::TEST_RESOURCE_FLOAT,      AwaResourceType_Float,      0, 1, AwaResourceOperations_ReadWrite, handler));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithHandler(client_, "Test Boolean Resource",     writeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, writeDetailDeprecated::TEST_RESOURCE_BOOLEAN,    AwaResourceType_Boolean,    0, 1, AwaResourceOperations_ReadWrite, handler));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithHandler(client_, "Test Opaque Resource",      writeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, writeDetailDeprecated::TEST_RESOURCE_OPAQUE,     AwaResourceType_Opaque,     0, 1, AwaResourceOperations_ReadWrite, handler));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithHandler(client_, "Test Time Resource",        writeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, writeDetailDeprecated::TEST_RESOURCE_TIME,       AwaResourceType_Time,       0, 1, AwaResourceOperations_ReadWrite, handler));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithHandler(client_, "Test Object Link Resource", writeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, writeDetailDeprecated::TEST_RESOURCE_OBJECTLINK, AwaResourceType_ObjectLink, 0, 1, AwaResourceOperations_ReadWrite, handler));
+        EXPECT_EQ(AwaError_Success, AwaStaticClient_CreateObjectInstance(client_, writeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0));
 
         AwaServerListClientsOperation * operation = AwaServerListClientsOperation_New(session_);
         EXPECT_TRUE(NULL != operation);
@@ -611,30 +588,30 @@ protected:
         AwaServerDefineOperation * serverDefineOperation = AwaServerDefineOperation_New(session_);
         EXPECT_TRUE(serverDefineOperation != NULL);
 
-        AwaObjectDefinition * customObjectDefinition = AwaObjectDefinition_New(writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, "Test Object Single", 0, 1);
+        AwaObjectDefinition * customObjectDefinition = AwaObjectDefinition_New(writeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, "Test Object Single", 0, 1);
         EXPECT_TRUE(NULL != customObjectDefinition);
 
-        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsString     (customObjectDefinition, writeDetail::TEST_RESOURCE_STRING,     "Test String Resource",      false, AwaResourceOperations_ReadWrite, NULL));
-        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsInteger    (customObjectDefinition, writeDetail::TEST_RESOURCE_INTEGER,    "Test Integer Resource",     false, AwaResourceOperations_ReadWrite, 0));
-        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsFloat      (customObjectDefinition, writeDetail::TEST_RESOURCE_FLOAT,      "Test Float Resource",       false, AwaResourceOperations_ReadWrite, 0.0));
-        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsBoolean    (customObjectDefinition, writeDetail::TEST_RESOURCE_BOOLEAN,    "Test Boolean Resource",     false, AwaResourceOperations_ReadWrite, false));
-        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsOpaque     (customObjectDefinition, writeDetail::TEST_RESOURCE_OPAQUE,     "Test Opaque Resource",      false, AwaResourceOperations_ReadWrite, AwaOpaque {0}));
-        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsTime       (customObjectDefinition, writeDetail::TEST_RESOURCE_TIME,       "Test Time Resource",        false, AwaResourceOperations_ReadWrite, 0));
-        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsObjectLink (customObjectDefinition, writeDetail::TEST_RESOURCE_OBJECTLINK, "Test Object Link Resource", false, AwaResourceOperations_ReadWrite, AwaObjectLink {0}));
+        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsString     (customObjectDefinition, writeDetailDeprecated::TEST_RESOURCE_STRING,     "Test String Resource",      false, AwaResourceOperations_ReadWrite, NULL));
+        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsInteger    (customObjectDefinition, writeDetailDeprecated::TEST_RESOURCE_INTEGER,    "Test Integer Resource",     false, AwaResourceOperations_ReadWrite, 0));
+        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsFloat      (customObjectDefinition, writeDetailDeprecated::TEST_RESOURCE_FLOAT,      "Test Float Resource",       false, AwaResourceOperations_ReadWrite, 0.0));
+        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsBoolean    (customObjectDefinition, writeDetailDeprecated::TEST_RESOURCE_BOOLEAN,    "Test Boolean Resource",     false, AwaResourceOperations_ReadWrite, false));
+        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsOpaque     (customObjectDefinition, writeDetailDeprecated::TEST_RESOURCE_OPAQUE,     "Test Opaque Resource",      false, AwaResourceOperations_ReadWrite, AwaOpaque {0}));
+        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsTime       (customObjectDefinition, writeDetailDeprecated::TEST_RESOURCE_TIME,       "Test Time Resource",        false, AwaResourceOperations_ReadWrite, 0));
+        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsObjectLink (customObjectDefinition, writeDetailDeprecated::TEST_RESOURCE_OBJECTLINK, "Test Object Link Resource", false, AwaResourceOperations_ReadWrite, AwaObjectLink {0}));
 
         EXPECT_EQ(AwaError_Success, AwaServerDefineOperation_Add(serverDefineOperation, customObjectDefinition));
         AwaObjectDefinition_Free(&customObjectDefinition);
 
-        customObjectDefinition = AwaObjectDefinition_New(writeDetail::TEST_OBJECT_ARRAY_TYPES, "Test Object Array", 0, 1);
+        customObjectDefinition = AwaObjectDefinition_New(writeDetailDeprecated::TEST_OBJECT_ARRAY_TYPES, "Test Object Array", 0, 1);
         EXPECT_TRUE(NULL != customObjectDefinition);
 
-        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsStringArray    (customObjectDefinition, writeDetail::TEST_RESOURCE_STRING,     "Test String Array Resource",      0,5, AwaResourceOperations_ReadWrite, NULL));
-        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsIntegerArray   (customObjectDefinition, writeDetail::TEST_RESOURCE_INTEGER,    "Test Integer Array Resource",     0,5, AwaResourceOperations_ReadWrite, NULL));
-        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsFloatArray     (customObjectDefinition, writeDetail::TEST_RESOURCE_FLOAT,      "Test Float Array Resource",       0,5, AwaResourceOperations_ReadWrite, NULL));
-        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsBooleanArray   (customObjectDefinition, writeDetail::TEST_RESOURCE_BOOLEAN,    "Test Boolean Array Resource",     0,5, AwaResourceOperations_ReadWrite, NULL));
-        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsOpaqueArray    (customObjectDefinition, writeDetail::TEST_RESOURCE_OPAQUE,     "Test Opaque Array Resource",      0,5, AwaResourceOperations_ReadWrite, NULL));
-        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsTimeArray      (customObjectDefinition, writeDetail::TEST_RESOURCE_TIME,       "Test Time Array Resource",        0,5, AwaResourceOperations_ReadWrite, NULL));
-        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsObjectLinkArray(customObjectDefinition, writeDetail::TEST_RESOURCE_OBJECTLINK, "Test Object Link Array Resource", 0,5, AwaResourceOperations_ReadWrite, NULL));
+        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsStringArray    (customObjectDefinition, writeDetailDeprecated::TEST_RESOURCE_STRING,     "Test String Array Resource",      0,5, AwaResourceOperations_ReadWrite, NULL));
+        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsIntegerArray   (customObjectDefinition, writeDetailDeprecated::TEST_RESOURCE_INTEGER,    "Test Integer Array Resource",     0,5, AwaResourceOperations_ReadWrite, NULL));
+        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsFloatArray     (customObjectDefinition, writeDetailDeprecated::TEST_RESOURCE_FLOAT,      "Test Float Array Resource",       0,5, AwaResourceOperations_ReadWrite, NULL));
+        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsBooleanArray   (customObjectDefinition, writeDetailDeprecated::TEST_RESOURCE_BOOLEAN,    "Test Boolean Array Resource",     0,5, AwaResourceOperations_ReadWrite, NULL));
+        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsOpaqueArray    (customObjectDefinition, writeDetailDeprecated::TEST_RESOURCE_OPAQUE,     "Test Opaque Array Resource",      0,5, AwaResourceOperations_ReadWrite, NULL));
+        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsTimeArray      (customObjectDefinition, writeDetailDeprecated::TEST_RESOURCE_TIME,       "Test Time Array Resource",        0,5, AwaResourceOperations_ReadWrite, NULL));
+        EXPECT_EQ(AwaError_Success, AwaObjectDefinition_AddResourceDefinitionAsObjectLinkArray(customObjectDefinition, writeDetailDeprecated::TEST_RESOURCE_OBJECTLINK, "Test Object Link Array Resource", 0,5, AwaResourceOperations_ReadWrite, NULL));
 
         EXPECT_EQ(AwaError_Success, AwaServerDefineOperation_Add(serverDefineOperation, customObjectDefinition));
         EXPECT_EQ(AwaError_Success, AwaServerDefineOperation_Perform(serverDefineOperation, defaults::timeout));
@@ -665,7 +642,7 @@ protected:
 
 static AwaResult TestWriteValueStaticClient_WriteHandler(void * context, AwaOperation operation, AwaObjectID objectID, AwaObjectInstanceID objectInstanceID, AwaResourceID resourceID, AwaResourceInstanceID resourceInstanceID, void ** dataPointer, size_t * dataSize, bool * changed)
 {
-    TestWriteReadStaticResource * data = static_cast<TestWriteReadStaticResource *>(context);
+    TestWriteReadStaticResourceDeprecated * data = static_cast<TestWriteReadStaticResourceDeprecated *>(context);
     EXPECT_EQ(AwaOperation_Write, operation);
     EXPECT_EQ(data->ObjectID, objectID);
     EXPECT_EQ(data->ObjectInstanceID, objectInstanceID);
@@ -685,7 +662,7 @@ static AwaResult TestWriteValueStaticClient_WriteHandler(void * context, AwaOper
 
 static AwaResult TestWriteValueStaticClient_ReadHandler(void * context, AwaOperation operation, AwaObjectID objectID, AwaObjectInstanceID objectInstanceID, AwaResourceID resourceID, AwaResourceInstanceID resourceInstanceID, void ** dataPointer, size_t * dataSize, bool * changed)
 {
-    TestWriteReadStaticResource * data = static_cast<TestWriteReadStaticResource *>(context);
+    TestWriteReadStaticResourceDeprecated * data = static_cast<TestWriteReadStaticResourceDeprecated *>(context);
 
     EXPECT_EQ(AwaOperation_Read, operation);
     EXPECT_EQ(data->ObjectID, objectID);
@@ -707,9 +684,9 @@ static AwaResult TestWriteValueStaticClient_ReadHandler(void * context, AwaOpera
     return AwaResult_SuccessContent;
 }
 
-TEST_P(TestStaticClienthandlerWriteReadValue, TestWriteReadValueSingle)
+TEST_P(TestStaticClientHandlerWriteReadValueDeprecated, TestWriteReadValueSingle)
 {
-    TestWriteReadStaticResource data = GetParam();
+    TestWriteReadStaticResourceDeprecated data = GetParam();
     char path[128] = {0};
 
     EXPECT_EQ(AwaError_Success, AwaAPI_MakePath(path, sizeof(path), data.ObjectID, data.ObjectInstanceID, data.ResourceID));
@@ -829,15 +806,15 @@ TEST_P(TestStaticClienthandlerWriteReadValue, TestWriteReadValueSingle)
 }
 
 INSTANTIATE_TEST_CASE_P(
-        TestStaticClientHandlerWriteReadValue,
-        TestStaticClienthandlerWriteReadValue,
+        TestStaticClientHandlerWriteReadValueDeprecated,
+        TestStaticClientHandlerWriteReadValueDeprecated,
         ::testing::Values(
-        TestWriteReadStaticResource {TestWriteValueStaticClient_WriteHandler, TestWriteValueStaticClient_ReadHandler, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, writeDetail::TEST_RESOURCE_STRING,     writeDetail::dummyString1,      1, static_cast<int>(strlen(writeDetail::dummyString1)),     AwaResourceType_String,     true, false},
-        TestWriteReadStaticResource {TestWriteValueStaticClient_WriteHandler, TestWriteValueStaticClient_ReadHandler, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, writeDetail::TEST_RESOURCE_INTEGER,    &writeDetail::dummyInteger1,    1, static_cast<int>(sizeof(writeDetail::dummyInteger1)),    AwaResourceType_Integer,    true, false},
-        TestWriteReadStaticResource {TestWriteValueStaticClient_WriteHandler, TestWriteValueStaticClient_ReadHandler, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, writeDetail::TEST_RESOURCE_FLOAT,      &writeDetail::dummyFloat1,      1, static_cast<int>(sizeof(writeDetail::dummyFloat1)),      AwaResourceType_Float,      true, false},
-        TestWriteReadStaticResource {TestWriteValueStaticClient_WriteHandler, TestWriteValueStaticClient_ReadHandler, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, writeDetail::TEST_RESOURCE_BOOLEAN,    &writeDetail::dummyBoolean1,    1, static_cast<int>(sizeof(writeDetail::dummyBoolean1)),    AwaResourceType_Boolean,    true, false},
-        TestWriteReadStaticResource {TestWriteValueStaticClient_WriteHandler, TestWriteValueStaticClient_ReadHandler, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, writeDetail::TEST_RESOURCE_OPAQUE,     writeDetail::dummyOpaqueData,   1, static_cast<int>(sizeof(writeDetail::dummyOpaqueData)),  AwaResourceType_Opaque,     true, false},
-        TestWriteReadStaticResource {TestWriteValueStaticClient_WriteHandler, TestWriteValueStaticClient_ReadHandler, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, writeDetail::TEST_RESOURCE_TIME,       &writeDetail::dummyTime1,       1, static_cast<int>(sizeof(writeDetail::dummyTime1)),       AwaResourceType_Time,       true, false},
-        TestWriteReadStaticResource {TestWriteValueStaticClient_WriteHandler, TestWriteValueStaticClient_ReadHandler, writeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, writeDetail::TEST_RESOURCE_OBJECTLINK, &writeDetail::dummyObjectLink1, 1, static_cast<int>(sizeof(writeDetail::dummyObjectLink1)), AwaResourceType_ObjectLink, true, false}
+        TestWriteReadStaticResourceDeprecated {TestWriteValueStaticClient_WriteHandler, TestWriteValueStaticClient_ReadHandler, writeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, writeDetailDeprecated::TEST_RESOURCE_STRING,     writeDetailDeprecated::dummyString1,      1, static_cast<int>(strlen(writeDetailDeprecated::dummyString1)),     AwaResourceType_String,     true, false},
+        TestWriteReadStaticResourceDeprecated {TestWriteValueStaticClient_WriteHandler, TestWriteValueStaticClient_ReadHandler, writeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, writeDetailDeprecated::TEST_RESOURCE_INTEGER,    &writeDetailDeprecated::dummyInteger1,    1, static_cast<int>(sizeof(writeDetailDeprecated::dummyInteger1)),    AwaResourceType_Integer,    true, false},
+        TestWriteReadStaticResourceDeprecated {TestWriteValueStaticClient_WriteHandler, TestWriteValueStaticClient_ReadHandler, writeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, writeDetailDeprecated::TEST_RESOURCE_FLOAT,      &writeDetailDeprecated::dummyFloat1,      1, static_cast<int>(sizeof(writeDetailDeprecated::dummyFloat1)),      AwaResourceType_Float,      true, false},
+        TestWriteReadStaticResourceDeprecated {TestWriteValueStaticClient_WriteHandler, TestWriteValueStaticClient_ReadHandler, writeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, writeDetailDeprecated::TEST_RESOURCE_BOOLEAN,    &writeDetailDeprecated::dummyBoolean1,    1, static_cast<int>(sizeof(writeDetailDeprecated::dummyBoolean1)),    AwaResourceType_Boolean,    true, false},
+        TestWriteReadStaticResourceDeprecated {TestWriteValueStaticClient_WriteHandler, TestWriteValueStaticClient_ReadHandler, writeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, writeDetailDeprecated::TEST_RESOURCE_OPAQUE,     writeDetailDeprecated::dummyOpaqueData,   1, static_cast<int>(sizeof(writeDetailDeprecated::dummyOpaqueData)),  AwaResourceType_Opaque,     true, false},
+        TestWriteReadStaticResourceDeprecated {TestWriteValueStaticClient_WriteHandler, TestWriteValueStaticClient_ReadHandler, writeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, writeDetailDeprecated::TEST_RESOURCE_TIME,       &writeDetailDeprecated::dummyTime1,       1, static_cast<int>(sizeof(writeDetailDeprecated::dummyTime1)),       AwaResourceType_Time,       true, false},
+        TestWriteReadStaticResourceDeprecated {TestWriteValueStaticClient_WriteHandler, TestWriteValueStaticClient_ReadHandler, writeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, writeDetailDeprecated::TEST_RESOURCE_OBJECTLINK, &writeDetailDeprecated::dummyObjectLink1, 1, static_cast<int>(sizeof(writeDetailDeprecated::dummyObjectLink1)), AwaResourceType_ObjectLink, true, false}
         ));
 } // namespace Awa

--- a/api/tests-static/test_static_api_with_pointer.cc
+++ b/api/tests-static/test_static_api_with_pointer.cc
@@ -32,32 +32,35 @@ class TestStaticClientWithPointerWithServer : public TestStaticClientWithServer 
 
 TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_Define_Invalid)
 {
-    EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_DefineObject(NULL, "TestObject", 7997, 0, 1));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_DefineObject(client_, NULL, 7997, 0, 1));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_DefineObject(client_, "TestObject", 7997, 2, 1));
-    EXPECT_EQ(AwaError_Success,             AwaStaticClient_DefineObject(client_, "TestObject", 7997, 0, 1)); // valid
+  EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_DefineObject(NULL, 7997, "TestObject", 0, 1));
+    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_DefineObject(client_, 7997, NULL, 0, 1));
+    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_DefineObject(client_, 7997, "TestObject", 2, 1));
+    EXPECT_EQ(AwaError_Success,             AwaStaticClient_DefineObject(client_, 7997, "TestObject", 0, 1)); // valid
 
-    EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_DefineResource(NULL,  "TestResource", 7997,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_DefineResource(client_, "TestResource", 300,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_DefineResource(client_, "TestResource", 7997,  1, AwaResourceType_Opaque, 2, 1, AwaResourceOperations_ReadWrite));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_DefineResource(client_, NULL, 7997,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
+    EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_DefineResource(NULL,    7997,  1, "TestResource", AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
+    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_DefineResource(client_, 300,   1, "TestResource", AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
+    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_DefineResource(client_, 7997,  1, "TestResource", AwaResourceType_Opaque, 2, 1, AwaResourceOperations_ReadWrite));
+    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_DefineResource(client_, 7997,  1, NULL,           AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
 }
 
 TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_SetResourceStorageWithPointer_Invalid)
 {
     AWA_OPAQUE(o, 10);
-    ASSERT_EQ(AwaError_Success,             AwaStaticClient_DefineObject(client_, "TestObject", 7997, 0, 1));
-    ASSERT_EQ(AwaError_Success,             AwaStaticClient_DefineResource(client_, "TestResource", 7997,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
-    EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_SetResourceStorageWithPointer(NULL,  7996,  1, &o, sizeof(o), 0));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointer(client_, 7997,  1, &o, 0, 0));
+    ASSERT_EQ(AwaError_Success,             AwaStaticClient_DefineObject(client_, 7997, "TestObject", 0, 1));
+    ASSERT_EQ(AwaError_Success,             AwaStaticClient_DefineResource(client_, 7997, 1, "TestResource", AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
+    EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_SetResourceStorageWithPointer(NULL,    7997,  1, &o,   sizeof(o), 0));
+    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointer(client_, 7996,  1, &o,   sizeof(o), 0));
+    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointer(client_, 7997,  2, &o,   sizeof(o), 0));
+    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointer(client_, 7997,  1, &o,   0, 0));
     EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointer(client_, 7997,  1, NULL, 0, 0));
+    EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_SetResourceStorageWithPointer(NULL,    7996,  2, NULL, 0, 0));
 }
 
 TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_SetResourceStorageWithPointer_Success)
 {
     AWA_OPAQUE(o, 10);
-    ASSERT_EQ(AwaError_Success,             AwaStaticClient_DefineObject(client_, "TestObject", 7997, 0, 1));
-    ASSERT_EQ(AwaError_Success,             AwaStaticClient_DefineResource(client_, "TestResource", 7997,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
+    ASSERT_EQ(AwaError_Success,             AwaStaticClient_DefineObject(client_, 7997, "TestObject", 0, 1));
+    ASSERT_EQ(AwaError_Success,             AwaStaticClient_DefineResource(client_, 7997, 1, "TestResource", AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
     EXPECT_EQ(AwaError_Success,             AwaStaticClient_SetResourceStorageWithPointer(client_,  7997,  1, &o, sizeof(o), 0));
 }
 
@@ -68,15 +71,15 @@ TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_SetResourceStorage
     AWA_OPAQUE(o3, 10);
     void * pointers[] = {&o1, &o2, &o3, NULL};
 
-    ASSERT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, "TestObject", 7996, 0, 1));
-    ASSERT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 3, AwaResourceOperations_ReadWrite));
+    ASSERT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, 7996, "TestObject", 0, 1));
+    ASSERT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, 7996, 1, "TestResource", AwaResourceType_Opaque, 1, 3, AwaResourceOperations_ReadWrite));
 
-    EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_SetResourceStorageWithPointerArray(NULL,  7996,  1, pointers, sizeof(o1)));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointerArray(client_, 7995,  1, pointers, sizeof(o1)));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointerArray(client_, 7996,  2, pointers, sizeof(o1)));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointerArray(client_, 7996, 1, NULL, sizeof(o1)));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointerArray(client_, 7996,  1, pointers, 0));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointerArray(NULL, 7995,  2, NULL, 0));
+    EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_SetResourceStorageWithPointerArray(NULL,    7996, 1, pointers, sizeof(o1)));
+    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointerArray(client_, 7995, 1, pointers, sizeof(o1)));
+    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointerArray(client_, 7996, 2, pointers, sizeof(o1)));
+    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointerArray(client_, 7996, 1, NULL,     sizeof(o1)));
+    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointerArray(client_, 7996, 1, pointers, 0));
+    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointerArray(NULL,    7995, 2, NULL,     0));
 }
 
 TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_SetResourceStorageWithPointerArray_Success)
@@ -86,8 +89,8 @@ TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_SetResourceStorage
     AWA_OPAQUE(o3, 10);
     void * pointers[] = {&o1, &o2, &o3, NULL};
 
-    ASSERT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, "TestObject", 7996, 0, 1));
-    ASSERT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 3, AwaResourceOperations_ReadWrite));
+    ASSERT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, 7996, "TestObject", 0, 1));
+    ASSERT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, 7996, 1, "TestResource", AwaResourceType_Opaque, 1, 3, AwaResourceOperations_ReadWrite));
 
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceStorageWithPointerArray(client_, 7996,  1, pointers, sizeof(o1)));
 }
@@ -98,8 +101,8 @@ TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_CreateObjectInstan
 
     EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_CreateObjectInstance(NULL, 9999, 0));
 
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, "TestObject", 205, 0, 1));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Resource", 205,  1, AwaResourceType_Integer, 0, 1, AwaResourceOperations_ReadWrite));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, 205, "TestObject", 0, 1));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, 205, 1, "Resource", AwaResourceType_Integer, 0, 1, AwaResourceOperations_ReadWrite));
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceStorageWithPointer(client_, 205, 1, &i, sizeof(i), 0));
 
     EXPECT_EQ(AwaError_Success, AwaStaticClient_CreateObjectInstance(client_, 205, 0));
@@ -117,8 +120,8 @@ TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_WithPointer_Create
 {
     AwaInteger i = 10;
 
-    EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObject(client_, "TestObject", 7999, 0, 1));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 7999, 1, AwaResourceType_Integer, 1, 1, AwaResourceOperations_ReadWrite));
+    EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObject(client_, 7999, "TestObject", 0, 1));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, 7999, 1, "TestResource", AwaResourceType_Integer, 1, 1, AwaResourceOperations_ReadWrite));
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceStorageWithPointer(client_, 7999, 1, &i, sizeof(i), 0));
 
     AwaServerListClientsOperation * operation = AwaServerListClientsOperation_New(session_);
@@ -159,8 +162,8 @@ TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_WithPointer_Create
 {
     // Static client definition
     AWA_OPAQUE(opaque, 16) = {0};
-    EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObject(client_, "TestObject", 7998, 0, 1));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 7998, 1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
+    EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObject(client_, 7998, "TestObject", 0, 1));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, 7998, 1, "TestResource", AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceStorageWithPointer(client_, 7998, 1, &opaque, sizeof(opaque), 0));
 
     // Server definition
@@ -203,8 +206,8 @@ TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_WithPointer_Create
 {
     // Static client definition
     AWA_OPAQUE(opaque, 16) = {0};
-    EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObject(client_, "TestObject", 7998, 0, 1));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 7998, 1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
+    EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObject(client_, 7998, "TestObject", 0, 1));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, 7998, 1, "TestResource", AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceStorageWithPointer(client_, 7998, 1, &opaque, sizeof(opaque), 0));
 
     // Server definition
@@ -271,8 +274,8 @@ TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_WithPointer_Create
 {
     // Static client definition
     char stringData[128] = {0};
-    EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObject(client_, "TestObject", 7998, 0, 1));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 7998, 1, AwaResourceType_String, 1, 1, AwaResourceOperations_ReadWrite));
+    EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObject(client_, 7998, "TestObject", 0, 1));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, 7998, 1, "TestResource", AwaResourceType_String, 1, 1, AwaResourceOperations_ReadWrite));
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceStorageWithPointer(client_, 7998, 1, &stringData, sizeof(stringData), 0));
 
     // Server definition
@@ -575,18 +578,18 @@ TEST_P(TestStaticClientObserveValue, TestObserveValueSingle)
     AwaServerObserveOperation * observeOperation = AwaServerObserveOperation_New(session_);
 
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetApplicationContext(client_, &cbHandler_));
-    EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObject(client_, "TestObject", observeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, 1));
+    EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObject(client_, observeDetail::TEST_OBJECT_NON_ARRAY_TYPES, "TestObject", 0, 1));
 
     switch(data.Type)
     {
         case AwaResourceType_Opaque:
         {
-            EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test Resource", data.ObjectID, data.ResourceID, data.Type, 1, 1, AwaResourceOperations_ReadOnly));
+          EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, data.ObjectID, data.ResourceID, "Test Resource", data.Type, 1, 1, AwaResourceOperations_ReadOnly));
             EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceStorageWithPointer(client_, data.ObjectID, data.ResourceID, &opaque_, sizeof(opaque_), 0));
             break;
         }
         default:
-            EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test Resource", data.ObjectID, data.ResourceID, data.Type, 1, 1, AwaResourceOperations_ReadOnly));
+          EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, data.ObjectID, data.ResourceID, "Test Resource", data.Type, 1, 1, AwaResourceOperations_ReadOnly));
             EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceStorageWithPointer(client_, data.ObjectID, data.ResourceID, data.Value, data.ValueSize, 0));
             break;
     }

--- a/api/tests-static/test_static_api_with_pointer.cc
+++ b/api/tests-static/test_static_api_with_pointer.cc
@@ -79,7 +79,7 @@ TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_SetResourceStorage
     EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointerArray(client_, 7996, 2, pointers, sizeof(o1)));
     EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointerArray(client_, 7996, 1, NULL,     sizeof(o1)));
     EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointerArray(client_, 7996, 1, pointers, 0));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointerArray(NULL,    7995, 2, NULL,     0));
+    EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_SetResourceStorageWithPointerArray(NULL,    7995, 2, NULL,     0));
 }
 
 TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_SetResourceStorageWithPointerArray_Success)

--- a/api/tests-static/test_static_api_with_pointer_deprecated.cc
+++ b/api/tests-static/test_static_api_with_pointer_deprecated.cc
@@ -13,12 +13,14 @@
 
  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE 
  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ************************************************************************************************************************/
+
+// NOTE: this file uses deprecated API functions.
 
 #include <pthread.h>
 #include <gtest/gtest.h>
@@ -28,79 +30,52 @@
 
 namespace Awa {
 
-class TestStaticClientWithPointerWithServer : public TestStaticClientWithServer {};
+class TestStaticClientWithPointerWithServerDeprecated : public TestStaticClientWithServer {};
 
-TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_Define_Invalid)
+TEST_F(TestStaticClientWithPointerWithServerDeprecated, AwaStaticClient_WithPointer_Invalid)
 {
+    AWA_OPAQUE(o, 10);
     EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_DefineObject(NULL, "TestObject", 7997, 0, 1));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_DefineObject(client_, NULL, 7997, 0, 1));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_DefineObject(client_, "TestObject", 7997, 2, 1));
-    EXPECT_EQ(AwaError_Success,             AwaStaticClient_DefineObject(client_, "TestObject", 7997, 0, 1)); // valid
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineObject(client_, NULL, 7997, 0, 1));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineObject(client_, "TestObject", 7997, 2, 1));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, "TestObject", 7997, 0, 1)); // valid
 
-    EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_DefineResource(NULL,  "TestResource", 7997,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_DefineResource(client_, "TestResource", 300,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_DefineResource(client_, "TestResource", 7997,  1, AwaResourceType_Opaque, 2, 1, AwaResourceOperations_ReadWrite));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_DefineResource(client_, NULL, 7997,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
+    EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_DefineResourceWithPointer(NULL,  "TestResource", 7997,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite,  &o, sizeof(o), 0));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointer(client_, "TestResource", 7997,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite,  &o, 0, 0));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointer(client_, "TestResource", 7997, 1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite, NULL, 0, 0));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointer(client_, "TestResource", 300,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite,  &o, sizeof(o), 0));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointer(client_, "TestResource", 7997,  1, AwaResourceType_Opaque, 2, 1, AwaResourceOperations_ReadWrite, &o, sizeof(o), 0));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointer(client_, NULL, 7997,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite, &o, sizeof(o), 0));
 }
 
-TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_SetResourceStorageWithPointer_Invalid)
-{
-    AWA_OPAQUE(o, 10);
-    ASSERT_EQ(AwaError_Success,             AwaStaticClient_DefineObject(client_, "TestObject", 7997, 0, 1));
-    ASSERT_EQ(AwaError_Success,             AwaStaticClient_DefineResource(client_, "TestResource", 7997,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
-    EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_SetResourceStorageWithPointer(NULL,  7996,  1, &o, sizeof(o), 0));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointer(client_, 7997,  1, &o, 0, 0));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointer(client_, 7997,  1, NULL, 0, 0));
-}
-
-TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_SetResourceStorageWithPointer_Success)
-{
-    AWA_OPAQUE(o, 10);
-    ASSERT_EQ(AwaError_Success,             AwaStaticClient_DefineObject(client_, "TestObject", 7997, 0, 1));
-    ASSERT_EQ(AwaError_Success,             AwaStaticClient_DefineResource(client_, "TestResource", 7997,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
-    EXPECT_EQ(AwaError_Success,             AwaStaticClient_SetResourceStorageWithPointer(client_,  7997,  1, &o, sizeof(o), 0));
-}
-
-TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_SetResourceStorageWithPointerArray_Invalid)
+TEST_F(TestStaticClientWithPointerWithServerDeprecated, AwaStaticClient_WithPointerArray)
 {
     AWA_OPAQUE(o1, 10);
     AWA_OPAQUE(o2, 10);
     AWA_OPAQUE(o3, 10);
     void * pointers[] = {&o1, &o2, &o3, NULL};
 
-    ASSERT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, "TestObject", 7996, 0, 1));
-    ASSERT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 3, AwaResourceOperations_ReadWrite));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, "TestObject", 7996, 0, 1)); // valid
 
-    EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_SetResourceStorageWithPointerArray(NULL,  7996,  1, pointers, sizeof(o1)));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointerArray(client_, 7995,  1, pointers, sizeof(o1)));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointerArray(client_, 7996,  2, pointers, sizeof(o1)));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointerArray(client_, 7996, 1, NULL, sizeof(o1)));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointerArray(client_, 7996,  1, pointers, 0));
-    EXPECT_EQ(AwaError_DefinitionInvalid,   AwaStaticClient_SetResourceStorageWithPointerArray(NULL, 7995,  2, NULL, 0));
+    EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_DefineResourceWithPointerArray(NULL,  "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 3, AwaResourceOperations_ReadWrite, pointers, sizeof(o1)));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointerArray(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite,  pointers, 0));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointerArray(client_, "TestResource", 7996, 1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite, NULL, sizeof(o1)));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointerArray(client_, "TestResource", 300,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite,  pointers, sizeof(o1)));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointerArray(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 2, 1, AwaResourceOperations_ReadWrite, pointers, sizeof(o1)));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointerArray(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 4, AwaResourceOperations_ReadWrite, pointers, sizeof(o1)));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointerArray(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 2, AwaResourceOperations_ReadWrite, pointers, sizeof(o1)));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithPointerArray(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 3, AwaResourceOperations_ReadWrite, pointers, sizeof(o1)));
 }
 
-TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_SetResourceStorageWithPointerArray_Success)
-{
-    AWA_OPAQUE(o1, 10);
-    AWA_OPAQUE(o2, 10);
-    AWA_OPAQUE(o3, 10);
-    void * pointers[] = {&o1, &o2, &o3, NULL};
 
-    ASSERT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, "TestObject", 7996, 0, 1));
-    ASSERT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 3, AwaResourceOperations_ReadWrite));
-
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceStorageWithPointerArray(client_, 7996,  1, pointers, sizeof(o1)));
-}
-
-TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_CreateObjectInstance_Resource_Invalid)
+TEST_F(TestStaticClientWithPointerWithServerDeprecated, AwaStaticClient_CreateObjectInstance_Resource_Invalid)
 {
     AwaInteger i = 0;
 
     EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_CreateObjectInstance(NULL, 9999, 0));
 
     EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineObject(client_, "TestObject", 205, 0, 1));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Resource", 205,  1, AwaResourceType_Integer, 0, 1, AwaResourceOperations_ReadWrite));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceStorageWithPointer(client_, 205, 1, &i, sizeof(i), 0));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithPointer(client_, "Resource", 205,  1, AwaResourceType_Integer, 0, 1, AwaResourceOperations_ReadWrite, &i, sizeof(i), 0));
 
     EXPECT_EQ(AwaError_Success, AwaStaticClient_CreateObjectInstance(client_, 205, 0));
     EXPECT_EQ(AwaError_CannotCreate, AwaStaticClient_CreateObjectInstance(client_, 205, 0));
@@ -113,13 +88,13 @@ TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_CreateObjectInstan
     EXPECT_EQ(AwaError_CannotCreate, AwaStaticClient_CreateResource(client_, 205, 0, 1));
 }
 
-TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_WithPointer_Create_and_Write_Operation_for_Object_and_Resource)
+TEST_F(TestStaticClientWithPointerWithServerDeprecated, AwaStaticClient_WithPointer_Create_and_Write_Operation_for_Object_and_Resource)
 {
     AwaInteger i = 10;
 
     EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObject(client_, "TestObject", 7999, 0, 1));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 7999, 1, AwaResourceType_Integer, 1, 1, AwaResourceOperations_ReadWrite));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceStorageWithPointer(client_, 7999, 1, &i, sizeof(i), 0));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithPointer(client_, "TestResource", 7999, 1, AwaResourceType_Integer, 1, 1, AwaResourceOperations_ReadWrite,
+                                                                            &i, sizeof(i), 0));
 
     AwaServerListClientsOperation * operation = AwaServerListClientsOperation_New(session_);
     EXPECT_TRUE(NULL != operation);
@@ -152,17 +127,16 @@ TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_WithPointer_Create
 
     AwaStaticClient_Process(client_);
 
-    ASSERT_EQ(5, i);
+    ASSERT_EQ(5, i); 
 }
 
-TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_WithPointer_Create_and_Write_Operation_CoAPtimeout)
+TEST_F(TestStaticClientWithPointerWithServerDeprecated, AwaStaticClient_WithPointer_Create_and_Write_Operation_CoAPtimeout)
 {
     // Static client definition
     AWA_OPAQUE(opaque, 16) = {0};
     EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObject(client_, "TestObject", 7998, 0, 1));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 7998, 1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceStorageWithPointer(client_, 7998, 1, &opaque, sizeof(opaque), 0));
-
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithPointer(client_, "TestResource", 7998, 1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite,
+                                                                            &opaque, sizeof(opaque), 0));
     // Server definition
     AwaServerListClientsOperation * operation = AwaServerListClientsOperation_New(session_);
     EXPECT_TRUE(NULL != operation);
@@ -199,14 +173,13 @@ TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_WithPointer_Create
 }
 
 
-TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_WithPointer_Create_and_Write_Operation_for_Object_and_Opaque_Resource)
+TEST_F(TestStaticClientWithPointerWithServerDeprecated, AwaStaticClient_WithPointer_Create_and_Write_Operation_for_Object_and_Opaque_Resource)
 {
     // Static client definition
     AWA_OPAQUE(opaque, 16) = {0};
     EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObject(client_, "TestObject", 7998, 0, 1));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 7998, 1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceStorageWithPointer(client_, 7998, 1, &opaque, sizeof(opaque), 0));
-
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithPointer(client_, "TestResource", 7998, 1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite,
+                                                                            &opaque, sizeof(opaque), 0));
     // Server definition
     AwaServerListClientsOperation * operation = AwaServerListClientsOperation_New(session_);
     EXPECT_TRUE(NULL != operation);
@@ -258,23 +231,22 @@ TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_WithPointer_Create
 
     const AwaServerReadResponse * readResponse = AwaServerReadOperation_GetResponse(readOperation, global::clientEndpointName);
     EXPECT_TRUE(readResponse != NULL);
-
+   
     AwaOpaque * value;
     ASSERT_EQ(AwaError_Success, AwaServerReadResponse_GetValueAsOpaquePointer(readResponse, "/7998/0/1", (const AwaOpaque **)&value));
     ASSERT_EQ(5, static_cast<int>(value->Size));
     ASSERT_TRUE(memcmp(value->Data, "Hello", 5) == 0);
-
+          
     AwaServerReadOperation_Free(&readOperation);
 }
 
-TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_WithPointer_Create_and_Write_Operation_for_Object_and_String_Resource)
+TEST_F(TestStaticClientWithPointerWithServerDeprecated, AwaStaticClient_WithPointer_Create_and_Write_Operation_for_Object_and_String_Resource)
 {
     // Static client definition
     char stringData[128] = {0};
     EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObject(client_, "TestObject", 7998, 0, 1));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "TestResource", 7998, 1, AwaResourceType_String, 1, 1, AwaResourceOperations_ReadWrite));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceStorageWithPointer(client_, 7998, 1, &stringData, sizeof(stringData), 0));
-
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithPointer(client_, "TestResource", 7998, 1, AwaResourceType_String, 1, 1, AwaResourceOperations_ReadWrite,
+                                                                            &stringData, sizeof(stringData), 0));
     // Server definition
     AwaServerListClientsOperation * operation = AwaServerListClientsOperation_New(session_);
     EXPECT_TRUE(NULL != operation);
@@ -335,7 +307,7 @@ TEST_F(TestStaticClientWithPointerWithServer, AwaStaticClient_WithPointer_Create
     AwaServerReadOperation_Free(&readOperation);
 }
 
-namespace observeDetail
+namespace observeDetailDeprecated
 {
 
 struct TestObserveResource
@@ -389,8 +361,7 @@ const AwaResourceID TEST_RESOURCE_BOOLEAN = 4;
 const AwaResourceID TEST_RESOURCE_OPAQUE = 5;
 const AwaResourceID TEST_RESOURCE_TIME = 6;
 const AwaResourceID TEST_RESOURCE_OBJECTLINK = 7;
-
-} // namespace observeDetail
+}
 
 typedef struct
 {
@@ -407,7 +378,7 @@ static void * do_observe_operation(void * attr)
     return 0;
 }
 
-struct TestObserveStaticResource
+struct TestObserveStaticResourceDeprecated
 {
     AwaObjectID ObjectID;
     AwaObjectInstanceID ObjectInstanceID;
@@ -419,7 +390,7 @@ struct TestObserveStaticResource
     AwaResourceType Type;
 };
 
-::std::ostream& operator<<(::std::ostream& os, const TestObserveStaticResource& item)
+::std::ostream& operator<<(::std::ostream& os, const TestObserveStaticResourceDeprecated& item)
 {
   return os << "Item: ObjectID " << item.ObjectID
             << ", ObjectInstanceID " << item.ObjectInstanceID
@@ -430,7 +401,7 @@ struct TestObserveStaticResource
             << ", Type " << item.Type;
 }
 
-class TestStaticClientObserveValue : public TestStaticClientWithServer, public ::testing::WithParamInterface< TestObserveStaticResource >
+class TestStaticClientObserveValueDeprecated : public TestStaticClientWithServer, public ::testing::WithParamInterface< TestObserveStaticResourceDeprecated >
 {
 public:
 
@@ -473,7 +444,7 @@ public:
     void callbackHandler(const AwaChangeSet * changeSet)
     {
         Lwm2m_Debug("Received notification %d\n", notificationCount_);
-        TestObserveStaticResource data = GetParam();
+        TestObserveStaticResourceDeprecated data = GetParam();
         const void * value = 0;
 
         char path[64];
@@ -559,14 +530,14 @@ static void (ChangeCallbackRunner)(const AwaChangeSet * changeSet, void * contex
 {
     if (context)
     {
-        auto * that = static_cast<TestStaticClientObserveValue*>(context);
+        auto * that = static_cast<TestStaticClientObserveValueDeprecated*>(context);
         that->callbackHandler(changeSet);
     }
 }
 
-TEST_P(TestStaticClientObserveValue, TestObserveValueSingle)
+TEST_P(TestStaticClientObserveValueDeprecated, TestObserveValueSingle)
 {
-    TestObserveStaticResource data = GetParam();
+    TestObserveStaticResourceDeprecated data = GetParam();
 
     ASSERT_TRUE(sizeof(opaque_) - sizeof(opaque_.Size) >= data.ValueSize);
     opaque_.Size = data.ValueSize;
@@ -575,22 +546,20 @@ TEST_P(TestStaticClientObserveValue, TestObserveValueSingle)
     AwaServerObserveOperation * observeOperation = AwaServerObserveOperation_New(session_);
 
     EXPECT_EQ(AwaError_Success, AwaStaticClient_SetApplicationContext(client_, &cbHandler_));
-    EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObject(client_, "TestObject", observeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, 1));
+    EXPECT_EQ(AwaError_Success,AwaStaticClient_DefineObject(client_, "TestObject", observeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, 1));
 
     switch(data.Type)
     {
         case AwaResourceType_Opaque:
         {
-            EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test Resource", data.ObjectID, data.ResourceID, data.Type, 1, 1, AwaResourceOperations_ReadOnly));
-            EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceStorageWithPointer(client_, data.ObjectID, data.ResourceID, &opaque_, sizeof(opaque_), 0));
+            EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithPointer(client_, "Test Resource", data.ObjectID, data.ResourceID, data.Type, 1, 1, AwaResourceOperations_ReadOnly, &opaque_, sizeof(opaque_), 0));
             break;
         }
         default:
-            EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResource(client_, "Test Resource", data.ObjectID, data.ResourceID, data.Type, 1, 1, AwaResourceOperations_ReadOnly));
-            EXPECT_EQ(AwaError_Success, AwaStaticClient_SetResourceStorageWithPointer(client_, data.ObjectID, data.ResourceID, data.Value, data.ValueSize, 0));
+            EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithPointer(client_, "Test Resource", data.ObjectID, data.ResourceID, data.Type, 1, 1, AwaResourceOperations_ReadOnly, data.Value, data.ValueSize, 0));
             break;
     }
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_CreateObjectInstance(client_, observeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_CreateObjectInstance(client_, observeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0));
 
     AwaServerListClientsOperation * operation = AwaServerListClientsOperation_New(session_);
     EXPECT_TRUE(NULL != operation);
@@ -663,16 +632,16 @@ TEST_P(TestStaticClientObserveValue, TestObserveValueSingle)
 }
 
 INSTANTIATE_TEST_CASE_P(
-        TestStaticClientObserveValue,
-        TestStaticClientObserveValue,
+        TestStaticClientObserveValueDeprecated,
+        TestStaticClientObserveValueDeprecated,
         ::testing::Values(
-        TestObserveStaticResource {observeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, observeDetail::TEST_RESOURCE_STRING, (void *)observeDetail::dummyInitialString1, (void *)observeDetail::dummyExpectedString1, strlen(observeDetail::dummyInitialString1) + 1,     AwaResourceType_String},
-        TestObserveStaticResource {observeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, observeDetail::TEST_RESOURCE_INTEGER,    &observeDetail::dummyInitialInteger1, &observeDetail::dummyExpectedInteger1, sizeof(observeDetail::dummyInitialInteger1),    AwaResourceType_Integer},
-        TestObserveStaticResource {observeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, observeDetail::TEST_RESOURCE_FLOAT,      &observeDetail::dummyInitialFloat1, &observeDetail::dummyExpectedFloat1,       sizeof(observeDetail::dummyInitialFloat1),      AwaResourceType_Float},
-        TestObserveStaticResource {observeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, observeDetail::TEST_RESOURCE_BOOLEAN,    &observeDetail::dummyInitialBoolean1, &observeDetail::dummyExpectedBoolean1,     sizeof(observeDetail::dummyInitialBoolean1),    AwaResourceType_Boolean},
-        TestObserveStaticResource {observeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, observeDetail::TEST_RESOURCE_OPAQUE,     observeDetail::dummyInitialOpaqueData, observeDetail::dummyExpectedOpaqueData,    sizeof(observeDetail::dummyInitialOpaqueData),  AwaResourceType_Opaque},
-        TestObserveStaticResource {observeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, observeDetail::TEST_RESOURCE_TIME,       &observeDetail::dummyInitialTime1, &observeDetail::dummyExpectedTime1,       sizeof(observeDetail::dummyInitialTime1),       AwaResourceType_Time},
-        TestObserveStaticResource {observeDetail::TEST_OBJECT_NON_ARRAY_TYPES, 0, observeDetail::TEST_RESOURCE_OBJECTLINK, &observeDetail::dummyInitialObjectLink1, &observeDetail::dummyExpectedObjectLink1, sizeof(observeDetail::dummyInitialObjectLink1), AwaResourceType_ObjectLink}
+        TestObserveStaticResourceDeprecated {observeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, observeDetailDeprecated::TEST_RESOURCE_STRING, (void *)observeDetailDeprecated::dummyInitialString1, (void *)observeDetailDeprecated::dummyExpectedString1, strlen(observeDetailDeprecated::dummyInitialString1) + 1,     AwaResourceType_String},
+        TestObserveStaticResourceDeprecated {observeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, observeDetailDeprecated::TEST_RESOURCE_INTEGER,    &observeDetailDeprecated::dummyInitialInteger1, &observeDetailDeprecated::dummyExpectedInteger1, sizeof(observeDetailDeprecated::dummyInitialInteger1),    AwaResourceType_Integer},
+        TestObserveStaticResourceDeprecated {observeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, observeDetailDeprecated::TEST_RESOURCE_FLOAT,      &observeDetailDeprecated::dummyInitialFloat1, &observeDetailDeprecated::dummyExpectedFloat1,       sizeof(observeDetailDeprecated::dummyInitialFloat1),      AwaResourceType_Float},
+        TestObserveStaticResourceDeprecated {observeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, observeDetailDeprecated::TEST_RESOURCE_BOOLEAN,    &observeDetailDeprecated::dummyInitialBoolean1, &observeDetailDeprecated::dummyExpectedBoolean1,     sizeof(observeDetailDeprecated::dummyInitialBoolean1),    AwaResourceType_Boolean},
+        TestObserveStaticResourceDeprecated {observeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, observeDetailDeprecated::TEST_RESOURCE_OPAQUE,     observeDetailDeprecated::dummyInitialOpaqueData, observeDetailDeprecated::dummyExpectedOpaqueData,    sizeof(observeDetailDeprecated::dummyInitialOpaqueData),  AwaResourceType_Opaque},
+        TestObserveStaticResourceDeprecated {observeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, observeDetailDeprecated::TEST_RESOURCE_TIME,       &observeDetailDeprecated::dummyInitialTime1, &observeDetailDeprecated::dummyExpectedTime1,       sizeof(observeDetailDeprecated::dummyInitialTime1),       AwaResourceType_Time},
+        TestObserveStaticResourceDeprecated {observeDetailDeprecated::TEST_OBJECT_NON_ARRAY_TYPES, 0, observeDetailDeprecated::TEST_RESOURCE_OBJECTLINK, &observeDetailDeprecated::dummyInitialObjectLink1, &observeDetailDeprecated::dummyExpectedObjectLink1, sizeof(observeDetailDeprecated::dummyInitialObjectLink1), AwaResourceType_ObjectLink}
         ));
 
 } // namespace Awa

--- a/api/tests-static/test_static_api_with_pointer_deprecated.cc
+++ b/api/tests-static/test_static_api_with_pointer_deprecated.cc
@@ -28,6 +28,10 @@
 #include "awa/server.h"
 #include "support/static_api_support.h"
 
+// reverse the name and objectID to match updated API:
+#define AwaStaticClient_DefineObject(A, B, C, D, E) AwaStaticClient_DefineObject(A, C, B, D, E)
+#define AwaStaticClient_DefineResource(A, B, C, D, E, F, G, H) AwaStaticClient_DefineResource(A, C, D, B, E, F, G, H)
+
 namespace Awa {
 
 class TestStaticClientWithPointerWithServerDeprecated : public TestStaticClientWithServer {};
@@ -42,10 +46,10 @@ TEST_F(TestStaticClientWithPointerWithServerDeprecated, AwaStaticClient_WithPoin
 
     EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_DefineResourceWithPointer(NULL,  "TestResource", 7997,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite,  &o, sizeof(o), 0));
     EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointer(client_, "TestResource", 7997,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite,  &o, 0, 0));
-    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointer(client_, "TestResource", 7997, 1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite, NULL, 0, 0));
-    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointer(client_, "TestResource", 300,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite,  &o, sizeof(o), 0));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointer(client_, "TestResource", 7997,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite, NULL, 0, 0));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointer(client_, "TestResource", 300,   1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite,  &o, sizeof(o), 0));
     EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointer(client_, "TestResource", 7997,  1, AwaResourceType_Opaque, 2, 1, AwaResourceOperations_ReadWrite, &o, sizeof(o), 0));
-    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointer(client_, NULL, 7997,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite, &o, sizeof(o), 0));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointer(client_, NULL,           7997,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite, &o, sizeof(o), 0));
 }
 
 TEST_F(TestStaticClientWithPointerWithServerDeprecated, AwaStaticClient_WithPointerArray)
@@ -59,12 +63,12 @@ TEST_F(TestStaticClientWithPointerWithServerDeprecated, AwaStaticClient_WithPoin
 
     EXPECT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_DefineResourceWithPointerArray(NULL,  "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 3, AwaResourceOperations_ReadWrite, pointers, sizeof(o1)));
     EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointerArray(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite,  pointers, 0));
-    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointerArray(client_, "TestResource", 7996, 1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite, NULL, sizeof(o1)));
-    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointerArray(client_, "TestResource", 300,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite,  pointers, sizeof(o1)));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointerArray(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite, NULL, sizeof(o1)));
+    EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointerArray(client_, "TestResource", 300,   1, AwaResourceType_Opaque, 1, 1, AwaResourceOperations_ReadWrite,  pointers, sizeof(o1)));
     EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointerArray(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 2, 1, AwaResourceOperations_ReadWrite, pointers, sizeof(o1)));
     EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointerArray(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 4, AwaResourceOperations_ReadWrite, pointers, sizeof(o1)));
     EXPECT_EQ(AwaError_DefinitionInvalid, AwaStaticClient_DefineResourceWithPointerArray(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 2, AwaResourceOperations_ReadWrite, pointers, sizeof(o1)));
-    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithPointerArray(client_, "TestResource", 7996,  1, AwaResourceType_Opaque, 1, 3, AwaResourceOperations_ReadWrite, pointers, sizeof(o1)));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_DefineResourceWithPointerArray(client_, "TestResource",           7996,  1, AwaResourceType_Opaque, 1, 3, AwaResourceOperations_ReadWrite, pointers, sizeof(o1)));
 }
 
 

--- a/core/src/client/lwm2m_static.c
+++ b/core/src/client/lwm2m_static.c
@@ -840,7 +840,11 @@ AwaError AwaStaticClient_DefineResource(AwaStaticClient * client, AwaObjectID ob
 AwaError AwaStaticClient_SetResourceOperationHandler(AwaStaticClient * client, AwaObjectID objectID, AwaResourceID resourceID, AwaStaticClientHandler handler)
 {
     AwaError result = AwaError_Unspecified;
-    if (handler == NULL)
+    if (client == NULL)
+    {
+        result = AwaError_StaticClientInvalid;
+    }
+    else if (handler == NULL)
     {
         result = AwaError_DefinitionInvalid;
     }
@@ -854,7 +858,11 @@ AwaError AwaStaticClient_SetResourceOperationHandler(AwaStaticClient * client, A
 AwaError AwaStaticClient_SetResourceStorageWithPointer(AwaStaticClient * client, AwaObjectID objectID, AwaResourceID resourceID, void * dataPointer, size_t dataElementSize, size_t dataStepSize)
 {
     AwaError result = AwaError_Unspecified;
-    if ((dataPointer == NULL) || (dataElementSize == 0))
+    if (client == NULL)
+    {
+        result = AwaError_StaticClientInvalid;
+    }
+    else if ((dataPointer == NULL) || (dataElementSize == 0))
     {
         result = AwaError_DefinitionInvalid;
     }
@@ -868,7 +876,11 @@ AwaError AwaStaticClient_SetResourceStorageWithPointer(AwaStaticClient * client,
 AwaError AwaStaticClient_SetResourceStorageWithPointerArray(AwaStaticClient * client, AwaObjectID objectID, AwaResourceID resourceID, void * dataPointers[], size_t dataElementSize)
 {
     AwaError result = AwaError_Unspecified;
-    if ((dataPointers == NULL) || (dataElementSize == 0))
+    if (client == NULL)
+    {
+        result = AwaError_StaticClientInvalid;
+    }
+    else if ((dataPointers == NULL) || (dataElementSize == 0))
     {
         result = AwaError_DefinitionInvalid;
     }

--- a/core/src/client/lwm2m_static.c
+++ b/core/src/client/lwm2m_static.c
@@ -761,16 +761,19 @@ static AwaError DefineResource(AwaStaticClient * client, const char * resourceNa
                 }
                 else
                 {
+                    Lwm2m_Warning("resourceDefinition is NULL\n");
                     result = AwaError_DefinitionInvalid;
                 }
             }
             else
             {
+                Lwm2m_Warning("objFormat is NULL\n");
                 result = AwaError_DefinitionInvalid;
             }
         }
         else
         {
+            Lwm2m_Warning("One or more Define parameters are invalid\n");
             result = AwaError_DefinitionInvalid;
         }
     }
@@ -782,10 +785,105 @@ static AwaError DefineResource(AwaStaticClient * client, const char * resourceNa
     return result;
 }
 
+static AwaError SetResourceStorage(AwaStaticClient * client, AwaObjectID objectID, AwaResourceID resourceID,
+                                   AwaStaticClientHandler handler,  void * dataPointers, bool isPointerArray,
+                                   size_t dataElementSize, size_t dataStepSize)
+{
+    AwaError result = AwaError_Unspecified;
+
+    if (client != NULL)
+    {
+        ObjectDefinition * objFormat = Definition_LookupObjectDefinition(Lwm2mCore_GetDefinitions(client->Context), objectID);
+        if (objFormat != NULL)
+        {
+            ResourceDefinition * resourceDefinition = Definition_LookupResourceDefinitionFromObjectDefinition(objFormat, resourceID);
+            if (resourceDefinition != NULL)
+            {
+                resourceDefinition->Handler = (LWM2MHandler)handler;
+                resourceDefinition->DataPointers = dataPointers;
+                resourceDefinition->IsPointerArray = isPointerArray;
+                resourceDefinition->DataElementSize = dataElementSize;
+                resourceDefinition->DataStepSize = dataStepSize;
+                result = AwaError_Success;
+            }
+            else
+            {
+                Lwm2m_Warning("resourceDefinition is NULL\n");
+                result = AwaError_DefinitionInvalid;
+            }
+        }
+        else
+        {
+            Lwm2m_Warning("objFormat is NULL\n");
+            result = AwaError_DefinitionInvalid;
+        }
+    }
+    else
+    {
+        Lwm2m_Warning("client is NULL\n");
+        result = AwaError_StaticClientInvalid;
+    }
+
+    return result;
+}
+
+AwaError AwaStaticClient_DefineResource(AwaStaticClient * client, const char * resourceName,
+                                        AwaObjectID objectID, AwaResourceID resourceID, AwaResourceType resourceType,
+                                        uint16_t minimumInstances, uint16_t maximumInstances, AwaResourceOperations operations)
+{
+    return DefineResource(client, resourceName,
+                          objectID, resourceID, resourceType,
+                          minimumInstances, maximumInstances, operations,
+                          DefaultHandler, NULL, false, 0, 0);
+}
+
+AwaError AwaStaticClient_SetResourceOperationHandler(AwaStaticClient * client, AwaObjectID objectID, AwaResourceID resourceID, AwaStaticClientHandler handler)
+{
+    AwaError result = AwaError_Unspecified;
+    if (handler == NULL)
+    {
+        result = AwaError_DefinitionInvalid;
+    }
+    else
+    {
+        result = SetResourceStorage(client, objectID, resourceID, handler, NULL, false, 0, 0);
+    }
+    return result;
+}
+
+AwaError AwaStaticClient_SetResourceStorageWithPointer(AwaStaticClient * client, AwaObjectID objectID, AwaResourceID resourceID, void * dataPointer, size_t dataElementSize, size_t dataStepSize)
+{
+    AwaError result = AwaError_Unspecified;
+    if ((dataPointer == NULL) || (dataElementSize == 0))
+    {
+        result = AwaError_DefinitionInvalid;
+    }
+    else
+    {
+        result = SetResourceStorage(client, objectID, resourceID, DefaultHandler, dataPointer, false, dataElementSize, dataStepSize);
+    }
+    return result;
+}
+
+AwaError AwaStaticClient_SetResourceStorageWithPointerArray(AwaStaticClient * client, AwaObjectID objectID, AwaResourceID resourceID, void * dataPointers[], size_t dataElementSize)
+{
+    AwaError result = AwaError_Unspecified;
+    if ((dataPointers == NULL) || (dataElementSize == 0))
+    {
+        result = AwaError_DefinitionInvalid;
+    }
+    else
+    {
+        result = SetResourceStorage(client, objectID, resourceID, DefaultHandler, dataPointers, true, dataElementSize, 0);
+    }
+    return result;
+}
+
+/** @deprecated */
 AwaError AwaStaticClient_DefineResourceWithPointer(AwaStaticClient * client, const char * resourceName,
-                                                     AwaObjectID objectID, AwaResourceID resourceID, AwaResourceType resourceType,
-                                                     uint16_t minimumInstances, uint16_t maximumInstances, AwaResourceOperations operations,
-                                                     void * dataPointer, size_t dataElementSize, size_t dataStepSize)
+                                                   AwaObjectID objectID, AwaResourceID resourceID, AwaResourceType resourceType,
+                                                   uint16_t minimumInstances, uint16_t maximumInstances, AwaResourceOperations operations,
+                                                   void * dataPointer, size_t dataElementSize, size_t dataStepSize)
 {
     AwaError result;
 
@@ -804,6 +902,7 @@ AwaError AwaStaticClient_DefineResourceWithPointer(AwaStaticClient * client, con
     return result;
 }
 
+/** @deprecated */
 AwaError AwaStaticClient_DefineResourceWithPointerArray(AwaStaticClient * client, const char * resourceName,
                                                         AwaObjectID objectID, AwaResourceID resourceID, AwaResourceType resourceType,
                                                         uint16_t minimumInstances, uint16_t maximumInstances, AwaResourceOperations operations,
@@ -839,6 +938,7 @@ AwaError AwaStaticClient_DefineResourceWithPointerArray(AwaStaticClient * client
     return result;
 }
 
+/** @deprecated */
 AwaError AwaStaticClient_DefineResourceWithHandler(AwaStaticClient * client, const char * resourceName,
                                                    AwaObjectID objectID, AwaResourceID resourceID, AwaResourceType resourceType,
                                                    uint16_t minimumInstances, uint16_t maximumInstances, AwaResourceOperations operations,

--- a/core/src/client/lwm2m_static.c
+++ b/core/src/client/lwm2m_static.c
@@ -540,7 +540,7 @@ static AwaResult DefaultHandler(AwaStaticClient * client, AwaOperation operation
     return result;
 }
 
-AwaError AwaStaticClient_DefineObject(AwaStaticClient * client, const char * objectName, AwaObjectID objectID,
+AwaError AwaStaticClient_DefineObject(AwaStaticClient * client, AwaObjectID objectID, const char * objectName,
                                       uint16_t minimumInstances, uint16_t maximumInstances)
 {
     AwaError result = AwaError_Unspecified;
@@ -827,8 +827,8 @@ static AwaError SetResourceStorage(AwaStaticClient * client, AwaObjectID objectI
     return result;
 }
 
-AwaError AwaStaticClient_DefineResource(AwaStaticClient * client, const char * resourceName,
-                                        AwaObjectID objectID, AwaResourceID resourceID, AwaResourceType resourceType,
+AwaError AwaStaticClient_DefineResource(AwaStaticClient * client, AwaObjectID objectID, AwaResourceID resourceID,
+                                        const char * resourceName, AwaResourceType resourceType,
                                         uint16_t minimumInstances, uint16_t maximumInstances, AwaResourceOperations operations)
 {
     return DefineResource(client, resourceName,

--- a/core/src/common/lwm2m_definition.c
+++ b/core/src/common/lwm2m_definition.c
@@ -76,8 +76,8 @@ ResourceDefinition * Definition_LookupResourceDefinition(const DefinitionRegistr
     return Definition_LookupResourceDefinitionFromObjectDefinition(objFormat, resourceID);
 }
 
-ObjectDefinition * NewObjectType(const char * objName, ObjectIDType objectID, uint16_t maximumInstances,
-                                            uint16_t minimumInstances, const ObjectOperationHandlers * handlers, LWM2MHandler handler)
+static ObjectDefinition * NewObjectType(const char * objName, ObjectIDType objectID, uint16_t maximumInstances,
+                                        uint16_t minimumInstances, const ObjectOperationHandlers * handlers, LWM2MHandler handler)
 {
     ObjectDefinition * objFormat = NULL;
     objFormat = (ObjectDefinition *)malloc(sizeof(ObjectDefinition));
@@ -118,28 +118,46 @@ ObjectDefinition * Definition_NewObjectType(const char * objName, ObjectIDType o
 }
 
 ObjectDefinition * Definition_NewObjectTypeWithHandler(const char * objName, ObjectIDType objectID, uint16_t minimumInstances,
-                                            uint16_t maximumInstances, LWM2MHandler handler)
+                                                       uint16_t maximumInstances, LWM2MHandler handler)
 {
     return NewObjectType(objName, objectID, maximumInstances, minimumInstances, NULL, handler);
+}
+
+int Definition_SetObjectHandler(ObjectDefinition * objectDefinition, LWM2MHandler handler)
+{
+    int result = -1;
+
+    if (objectDefinition != NULL)
+    {
+        objectDefinition->Handler = handler;
+        result = 0;
+    }
+    else
+    {
+        Lwm2m_Error("objectDefinition is NULL\n");
+        result = -1;
+    }
+
+    return result;
 }
 
 int Definition_AddObjectType(DefinitionRegistry * registry, ObjectDefinition * objFormat)
 {
     int result = -1;
-    ObjectDefinition * ExistingObjFormat = NULL;
+    ObjectDefinition * existingObjFormat = NULL;
 
-    if ((ExistingObjFormat = Definition_LookupObjectDefinition(registry, objFormat->ObjectID)))
+    if ((existingObjFormat = Definition_LookupObjectDefinition(registry, objFormat->ObjectID)))
     {
-        if (objFormat->MaximumInstances != ExistingObjFormat->MaximumInstances)
+        if (objFormat->MaximumInstances != existingObjFormat->MaximumInstances)
         {
             AwaResult_SetResult(AwaResult_MismatchedDefinition);
         }
-        else if (strlen(ExistingObjFormat->ObjectName) != strlen(objFormat->ObjectName) ||
-                 memcmp(ExistingObjFormat->ObjectName, objFormat->ObjectName, strlen(ExistingObjFormat->ObjectName)))
+        else if (strlen(existingObjFormat->ObjectName) != strlen(objFormat->ObjectName) ||
+                 memcmp(existingObjFormat->ObjectName, objFormat->ObjectName, strlen(existingObjFormat->ObjectName)))
         {
             AwaResult_SetResult(AwaResult_MismatchedDefinition);
         }
-        else if (objFormat->MinimumInstances != ExistingObjFormat->MinimumInstances)
+        else if (objFormat->MinimumInstances != existingObjFormat->MinimumInstances)
         {
             AwaResult_SetResult(AwaResult_MismatchedDefinition);
         }

--- a/core/src/common/lwm2m_definition.h
+++ b/core/src/common/lwm2m_definition.h
@@ -140,7 +140,8 @@ ResourceDefinition * Definition_LookupResourceDefinitionFromObjectDefinition(con
 ObjectDefinition * Definition_NewObjectType(const char * objName, ObjectIDType objectID, uint16_t maximumInstances,
                                             uint16_t minimumInstances, const ObjectOperationHandlers * handlers);
 ObjectDefinition * Definition_NewObjectTypeWithHandler(const char * objName, ObjectIDType objectID, uint16_t minimumInstances,
-                                            uint16_t maximumInstances, LWM2MHandler handler);
+                                                       uint16_t maximumInstances, LWM2MHandler handler);
+int Definition_SetObjectHandler(ObjectDefinition * objFormat, LWM2MHandler handler);
 void Definition_FreeObjectType(ObjectDefinition * definition);
 int Definition_AddObjectType(DefinitionRegistry * registry, ObjectDefinition * objFormat);
 ObjectDefinition * Definition_CopyObjectDefinition(const ObjectDefinition * definition);

--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -165,5 +165,10 @@ Awa LightweightM2M was developed alongside a comprehensive test suite, implement
 
 TODO
 
+## Best Practices
 
+TODO
 
+## FAQ
+
+TODO


### PR DESCRIPTION
These changes are intended to improve consistency with the Gateway API, and separate the concerns of Object/Resource _definition_ from how the entity is managed or stored. This results in the deprecation of some existing API functions. These deprecated functions will be removed after 0.1.8 has been released.

Also includes a minor documentation update by reserving a section for "Best Practices".