### PR TITLE
ABANDONED? Change cmake to accept CMAKE_INSTALL_PREFIX

### DIFF
--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -9,6 +9,6 @@ if (BUILD_TESTS)
 endif ()
 
 install (DIRECTORY include/awa
-  DESTINATION /usr/include
+  DESTINATION include
 )
 

--- a/api/src/CMakeLists.txt
+++ b/api/src/CMakeLists.txt
@@ -105,6 +105,6 @@ set_target_properties (Awa_shared PROPERTIES OUTPUT_NAME "awa")
 target_link_libraries (Awa_shared libxml_static libb64_static libhmac_static)
 
 install (TARGETS Awa_shared
-   LIBRARY DESTINATION /usr/lib
+   LIBRARY DESTINATION lib
 )
 

--- a/core/src/bootstrap/CMakeLists.txt
+++ b/core/src/bootstrap/CMakeLists.txt
@@ -44,6 +44,6 @@ if (ENABLE_GCOV)
 endif ()
 
 install (TARGETS awa_bootstrapd
-    RUNTIME DESTINATION /bin
+    RUNTIME DESTINATION bin
 )
 

--- a/core/src/client/CMakeLists.txt
+++ b/core/src/client/CMakeLists.txt
@@ -105,9 +105,9 @@ if (ENABLE_GCOV)
 endif ()
 
 install (TARGETS awa_clientd
-    RUNTIME DESTINATION /bin
+    RUNTIME DESTINATION bin
 )
 
 install (TARGETS awa_static_shared
-    LIBRARY DESTINATION /usr/lib
+    LIBRARY DESTINATION lib
 )

--- a/core/src/server/CMakeLists.txt
+++ b/core/src/server/CMakeLists.txt
@@ -94,5 +94,5 @@ if (ENABLE_GCOV)
 endif ()
 
 install (TARGETS awa_serverd
-  RUNTIME DESTINATION /bin
+  RUNTIME DESTINATION bin
 )

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -60,7 +60,7 @@ foreach (tool ${DefineTools})
 endforeach ()
 
 install (TARGETS ${DefineTools}
-  RUNTIME DESTINATION /bin
+  RUNTIME DESTINATION bin
 )
 
 foreach (tool ${Tools})
@@ -79,7 +79,7 @@ foreach (tool ${Tools})
 endforeach (tool ${Tools})
 
 install (TARGETS ${Tools}
-  RUNTIME DESTINATION /bin
+  RUNTIME DESTINATION bin
 )
 
 if (BUILD_TESTS)


### PR DESCRIPTION
Cmake now accepts CMAKE_INSTALL_PREFIX:

    cmake -DCMAKE_INSTALL_PREFIX:PATH=/path/to/install
    make install