### PR TITLE
cmake installation changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,23 +21,36 @@
 #
 ##
 
-# default location for out-of-source build:
+# The purpose of this makefile is to encapsulate the build system (e.g. cmake)
+# within a simple make interface, so that common tasks are simple to run.
+#
+# If desired, this makefile can be ignored and cmake run directly:
+#
+#   $ mkdir builddir
+#   $ cd builddir
+#   $ cmake ..
+#
+
+# Default location for out-of-source build results:
 BUILD_DIR:=./build
 
-# default path prefix for installing build results:
-INSTALL_PREFIX:=/usr/local
+# Default path prefix for installing build results:
+INSTALL_PREFIX:=/
+
+# Use 'make install DESTDIR=/path' to install into a staging directory.
+# Note that the resulting path will include INSTALL_PREFIX.
 
 
 ###############################################################################
 # Rules
 
 ifeq ($(DEBUG),)
-#  CMAKE_OPTIONS+=-DCMAKE_BUILD_TYPE=Release
+#  override CMAKE_OPTIONS+=-DCMAKE_BUILD_TYPE=Release
 else
-  CMAKE_OPTIONS+=-DCMAKE_BUILD_TYPE=Debug
+  override CMAKE_OPTIONS+=-DCMAKE_BUILD_TYPE=Debug
 endif
 
-CMAKE_OPTIONS+=-DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
+override CMAKE_OPTIONS+=-DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}
 
 # absolute path of BUILD_DIR
 BUILD_DIR_ABS:=$(shell pwd)/$(BUILD_DIR)
@@ -47,8 +60,7 @@ all: $(BUILD_DIR)/Makefile
 	@echo "Build complete in directory $(BUILD_DIR)"
 
 install: all
-	cd $(BUILD_DIR); $(MAKE) install DESTDIR=./install
-	@echo "AwaLWM2M installed to $(BUILD_DIR)/install"
+	$(MAKE) -C $(BUILD_DIR) --no-print-directory install
 
 $(BUILD_DIR)/Makefile:
 	mkdir -p $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,11 @@
 #
 ##
 
+# default location for out-of-source build:
 BUILD_DIR:=./build
 
-_STAGING_DIR:=./staging
+# default path prefix for installing build results:
+INSTALL_PREFIX:=/usr/local
 
 
 ###############################################################################
@@ -34,6 +36,8 @@ ifeq ($(DEBUG),)
 else
   CMAKE_OPTIONS+=-DCMAKE_BUILD_TYPE=Debug
 endif
+
+CMAKE_OPTIONS+=-DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
 
 # absolute path of BUILD_DIR
 BUILD_DIR_ABS:=$(shell pwd)/$(BUILD_DIR)
@@ -144,7 +148,6 @@ api-clean:
 
 clean: api-clean
 	rm -rf $(BUILD_DIR)
-	rm -rf $(_STAGING_DIR)
 	rm -rf $(VALGRIND_LOG_DIR)
 	rm -f *.log
 	rm -f *_out.xml

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -9,6 +9,6 @@ if (BUILD_TESTS)
 endif ()
 
 install (DIRECTORY include/awa
-  DESTINATION /usr/include
+  DESTINATION include
 )
 

--- a/api/examples/tutorials/Makefile
+++ b/api/examples/tutorials/Makefile
@@ -1,8 +1,9 @@
-INSTALL_PATH:=../../../build/install
+# This makefile assumes that Awa has been built with the default INSTALL_PREFIX and DESTDIR=install.
+AWA_INSTALL_PATH:=../../../build/install
 
 all:
-	$(CC) client-tutorial1.c -o client-tutorial1 -I$(INSTALL_PATH)/usr/include -L$(INSTALL_PATH)/usr/lib -lawa
-	$(CC) client-tutorial2.c -o client-tutorial2 -I$(INSTALL_PATH)/usr/include -L$(INSTALL_PATH)/usr/lib -lawa
-	$(CC) server-tutorial.c -o server-tutorial -I$(INSTALL_PATH)/usr/include -L$(INSTALL_PATH)/usr/lib -lawa
-	$(CC) static-client-tutorial1.c -o static-client-tutorial1 -I$(INSTALL_PATH)/usr/include -L$(INSTALL_PATH)/usr/lib -lawa_static
-	$(CC) static-client-tutorial2.c -o static-client-tutorial2 -I$(INSTALL_PATH)/usr/include -L$(INSTALL_PATH)/usr/lib -lawa_static
+	$(CC) client-tutorial1.c -o client-tutorial1 -I$(AWA_INSTALL_PATH)/usr/include -L$(AWA_INSTALL_PATH)/usr/lib -lawa
+	$(CC) client-tutorial2.c -o client-tutorial2 -I$(AWA_INSTALL_PATH)/usr/include -L$(AWA_INSTALL_PATH)/usr/lib -lawa
+	$(CC) server-tutorial.c -o server-tutorial -I$(AWA_INSTALL_PATH)/usr/include -L$(AWA_INSTALL_PATH)/usr/lib -lawa
+	$(CC) static-client-tutorial1.c -o static-client-tutorial1 -I$(AWA_INSTALL_PATH)/usr/include -L$(AWA_INSTALL_PATH)/usr/lib -lawa_static
+	$(CC) static-client-tutorial2.c -o static-client-tutorial2 -I$(AWA_INSTALL_PATH)/usr/include -L$(AWA_INSTALL_PATH)/usr/lib -lawa_static

--- a/api/src/CMakeLists.txt
+++ b/api/src/CMakeLists.txt
@@ -105,6 +105,6 @@ set_target_properties (Awa_shared PROPERTIES OUTPUT_NAME "awa")
 target_link_libraries (Awa_shared libxml_static libb64_static libhmac_static)
 
 install (TARGETS Awa_shared
-   LIBRARY DESTINATION /usr/lib
+   LIBRARY DESTINATION lib
 )
 

--- a/core/src/bootstrap/CMakeLists.txt
+++ b/core/src/bootstrap/CMakeLists.txt
@@ -44,6 +44,6 @@ if (ENABLE_GCOV)
 endif ()
 
 install (TARGETS awa_bootstrapd
-    RUNTIME DESTINATION /bin
+    RUNTIME DESTINATION bin
 )
 

--- a/core/src/client/CMakeLists.txt
+++ b/core/src/client/CMakeLists.txt
@@ -105,9 +105,9 @@ if (ENABLE_GCOV)
 endif ()
 
 install (TARGETS awa_clientd
-    RUNTIME DESTINATION /bin
+    RUNTIME DESTINATION bin
 )
 
 install (TARGETS awa_static_shared
-    LIBRARY DESTINATION /usr/lib
+    LIBRARY DESTINATION lib
 )

--- a/core/src/server/CMakeLists.txt
+++ b/core/src/server/CMakeLists.txt
@@ -94,5 +94,5 @@ if (ENABLE_GCOV)
 endif ()
 
 install (TARGETS awa_serverd
-  RUNTIME DESTINATION /bin
+  RUNTIME DESTINATION bin
 )

--- a/doc/example_app.md
+++ b/doc/example_app.md
@@ -29,23 +29,23 @@ The client-tutorial application makes use of the Awa API to define objects and r
 
 ![](client-tutorial.png)
 
-
+Note that this example assumes you have downloaded and decompressed (or git-cloned) Awa LWM2M into the directory `~/AwaLWM2M`.
 
 ## Awa LightweightM2M installation.
 
-Use the commands below to build and install Awa LightweightM2M to the  *./build/install* directory:
+Use the command below to build and install Awa LightweightM2M to the  *./build/install* directory:
 
 ```
-~/AwaLWM2M$ make
-~/AwaLWM2M$ cd build
-~/AwaLWM2M/build$ make install DESTDIR=./install
+~/AwaLWM2M $ make install DESTDIR=install
 ```
 
-Alternatively, you can use the following command to install into the default directory given above:
+Alternatively, you can use the following command to install into the default directory on your system:
 
 ```
-~/AwaLWM2M$ make install
+~/AwaLWM2M $ sudo make install
 ```
+
+This example will assume that you have installed it to `~/AwaLWM2M/build/install`.
 
 ----
 
@@ -64,7 +64,7 @@ To create the makefile, copy the code below to tutorial/*Makefile*. Be sure to r
 
 ```make
 all:
-	$(CC) client-tutorial.c -o client-tutorial -I$(INSTALL_PATH)/usr/include -L$(INSTALL_PATH)/usr/lib -lawa
+	$(CC) client-tutorial.c -o client-tutorial -I$(AWA_INSTALL_PATH)/usr/include -L$(AWA_INSTALL_PATH)/usr/lib -lawa
 ```
 
 Now is a good time to define our objects and resources:
@@ -123,7 +123,7 @@ int main(void)
 Now build the application...
 
 ```
-~/tutorial$ make INSTALL_PATH=~/AwaLWM2M/build/install
+~/tutorial$ make AWA_INSTALL_PATH=~/AwaLWM2M/build/install
 ```
 
 Start the client daemon...
@@ -249,7 +249,7 @@ int main(void)
 After updating the application code, rebuild the application:
 
 ```
-~/tutorial$ make INSTALL_PATH=~/AwaLWM2M/build/install
+~/tutorial$ make AWA_INSTALL_PATH=~/AwaLWM2M/build/install
 ```
 
 And restart the client daemon:
@@ -328,14 +328,14 @@ Now update tutorial/Makefile to include *server-tutorial.c* like so:
 
 ```make
 all:
-        $(CC) client-tutorial.c -o client-tutorial -I$(INSTALL_PATH)/usr/include -L$(INSTALL_PATH)/usr/lib -lawa
-        $(CC) server-tutorial.c -o server-tutorial -I$(INSTALL_PATH)/usr/include -L$(INSTALL_PATH)/usr/lib -lawa
+        $(CC) client-tutorial.c -o client-tutorial -I$(AWA_INSTALL_PATH)/usr/include -L$(AWA_INSTALL_PATH)/usr/lib -lawa
+        $(CC) server-tutorial.c -o server-tutorial -I$(AWA_INSTALL_PATH)/usr/include -L$(AWA_INSTALL_PATH)/usr/lib -lawa
 ```
 
 Build the new application:
 
 ```
-~/tutorial$ make INSTALL_PATH=~/AwaLWM2M/build/install
+~/tutorial$ make AWA_INSTALL_PATH=~/AwaLWM2M/build/install
 ```
 
 Restart the client/server daemon:
@@ -409,7 +409,7 @@ Copy the following code into static-client-tutorial/*Makefile*:
 
 ```make
 all:
-	$(CC) static-client-tutorial.c -o static-client-tutorial -I$(INSTALL_PATH)/usr/include -L$(INSTALL_PATH)/usr/lib -lawa_static
+	$(CC) static-client-tutorial.c -o static-client-tutorial -I$(AWA_INSTALL_PATH)/usr/include -L$(AWA_INSTALL_PATH)/usr/lib -lawa_static
 ```
 
 Copy the following code into static-client-tutorial/*static-client-tutorial.c*:
@@ -445,7 +445,7 @@ Run "make" and specify the install path to Awa LWM2M:
 
 ```
 $ cd static-client-tutorial
-static-client-tutorial $ make INSTALL_PATH=~/AwaLWM2M/build/install
+static-client-tutorial $ make AWA_INSTALL_PATH=~/AwaLWM2M/build/install
 ```
 
 Start the bootstrap and server daemons:

--- a/doc/starters_guide.md
+++ b/doc/starters_guide.md
@@ -29,7 +29,7 @@ Install the dependencies:
 Run make in the root directory of the Awa LWM2M repository
 
 
-````$ make````
+```$ make```
 
 
 This will produce the following executable files:
@@ -41,6 +41,31 @@ This will produce the following executable files:
  
 For usage information see the [User guide](userguide.md)
 
+##### Additional commands
+
+The variable `INSTALL_PREFIX` can be specified to modify the path where the build results will be installed *at configuration time*. For example:
+
+```$ make INSTALL_PREFIX=/usr``` 
+
+Note that this must be set at the very first invocation of make, or after `make clean`. Setting it later will not affect the install path.
+ 
+By default, this is set to `/` which will result in build artefacts being installed into /bin, /lib and /include.
+
+The variable `DESTDIR` can be set at the time `make install` is called. The final path is a combination of `INSTALL_PREFIX` and `DESTDIR`.
+
+For example, the following will build and install such that binaries are placed in /tmp/usr/bin:
+
+```
+    $ make INSTALL_PREFIX=/usr
+    $ make install DESTDIR=/tmp
+``` 
+
+If you want to install Awa into /usr/local/bin, the following commands are suggested:
+
+```
+    $ make
+    $ make install DESTDIR=/usr/local
+```
 
 #### The cmake build.
 
@@ -51,27 +76,32 @@ The build can be created out-of-source, such that all build artefacts are placed
 First, create a suitable directory for the build output:
 
 
-````$ mkdir build ````
+```$ mkdir build ```
 
 
 From this directory, run cmake, passing the path to the root directory of the repository as a parameter:
-````
 
+```
     $ cd build
     $ cmake ..
-````
+```
 
 
 This generates a Makefile in the build directory, which can be run to generate the build artefacts:
 
 
-````$ make ````
+```$ make ```
 
 
 Once the build is complete you may optionally *install* the resulting binaries to a specified directory, for example:
 
 
-````$ make DESTDIR=./install install ````
+```$ make DESTDIR=./install install ```
+
+
+Cmake options can be passed to cmake from the top-level makefile with the variable `CMAKE_OPTIONS`. For example:
+
+```$ make CMAKE_OPTIONS=-DBUILD_TESTS=OFF```
 
 
 ----

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -60,7 +60,7 @@ foreach (tool ${DefineTools})
 endforeach ()
 
 install (TARGETS ${DefineTools}
-  RUNTIME DESTINATION /bin
+  RUNTIME DESTINATION bin
 )
 
 foreach (tool ${Tools})
@@ -79,7 +79,7 @@ foreach (tool ${Tools})
 endforeach (tool ${Tools})
 
 install (TARGETS ${Tools}
-  RUNTIME DESTINATION /bin
+  RUNTIME DESTINATION bin
 )
 
 if (BUILD_TESTS)


### PR DESCRIPTION
Change cmake to accept CMAKE_INSTALL_PREFIX.

Add install prefix variable to top-level Makefile, so that installation prefix can be specified at build time. Default is set to /usr/local. Override with 'make INSTALL_PREFIX=/path/to/install/to.