### PR TITLE
Filter deprecation doxygen warnings to prevent build breaking with Ubuntu 15.10+.

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -6,7 +6,7 @@ doc docs: doc-html
 export VERSION:=$(shell cat ../VERSION)
 
 doc-html:
-	cd doc && doxygen 2>&1 >/dev/null | ( ! grep . )
+	cd doc && doxygen 2>&1 >/dev/null | ./doxygen-err-filter.sh | ( ! grep . )
 
 doc-pdf:
 	$(MAKE) -C doc/latex

--- a/api/doc/doxygen-err-filter.sh
+++ b/api/doc/doxygen-err-filter.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Filter doxygen output for acceptable warnings
+
+stdin=$(cat)
+echo "$stdin" | grep -v "has become obsolete." \
+              | grep -v "To avoid this warning please remove this line from your configuration file"


### PR DESCRIPTION
Signed-off-by: David Antliff <david.antliff@imgtec.com>