### PR TITLE
Add support for pic32 platform

### DIFF
--- a/core/src/common/dtls_abstraction_cyassl.c
+++ b/core/src/common/dtls_abstraction_cyassl.c
@@ -30,6 +30,13 @@
 #define CYASSL_DTLS
 #endif
 
+#ifdef MICROCHIP_PIC32
+#ifndef XMALLOC_USER
+#define XMALLOC_USER
+#endif
+#include <tcpip/berkeley_api.h>
+#endif // MICROCHIP_PIC32
+
 #include "cyassl/ssl.h"
 #include "cyassl/version.h"
 #include "cyassl/ctaocrypt/memory.h"
@@ -70,6 +77,11 @@ static int EncryptCallBack(CYASSL *sslSessioon, char *sendBuffer, int sendBuffer
 static unsigned int PSKCallBack(CYASSL* sslSession, const char* hint, char* identity, unsigned int id_max_len, unsigned char* key, unsigned int key_max_len);
 static int SSLSendCallBack(CYASSL *sslSessioon, char *sendBuffer, int sendBufferLength, void *vp);
 
+#ifdef MICROCHIP_PIC32
+#ifndef wolfDTLSv1_2_client_method
+WOLFSSL_METHOD* wolfDTLSv1_2_client_method(void);
+#endif
+#endif
 
 void *XMALLOC(size_t n, void* heap, int type)
 {

--- a/core/src/common/lwm2m_tlv.c
+++ b/core/src/common/lwm2m_tlv.c
@@ -29,16 +29,20 @@
 #include <float.h>
 
 #ifndef CONTIKI
-  #include <arpa/inet.h> // htons
-  #define htonll(x) ((1==htonl(1)) ? (x) : ((uint64_t)htonl((x) & 0xFFFFFFFF) << 32) | htonl((x) >> 32))
-  #define ntohll(x) ((1==ntohl(1)) ? (x) : ((uint64_t)ntohl((x) & 0xFFFFFFFF) << 32) | ntohl((x) >> 32))
+#ifdef MICROCHIP_PIC32
+    //#include <tcpip/tcpip_helpers.h>
+    #define htonl(x) (((x & 0x000000ff) << 24) | ((x & 0x0000ff00) << 8) | ((x & 0x00ff0000) >> 8) | ((x & 0xff000000) >> 24))
+    #define ntohl(x) htonl(x)
+#else
+    #include <arpa/inet.h> // htons
+#endif
 #else
   #include "net/ip/uip.h"  
-  #define htonll(x) ((1==uip_htonl(1)) ? (x) : ((uint64_t)uip_htonl((x) & 0xFFFFFFFF) << 32) | uip_htonl((x) >> 32))
-  #define ntohll(x) ((1==uip_ntohl(1)) ? (x) : ((uint64_t)uip_ntohl((x) & 0xFFFFFFFF) << 32) | uip_ntohl((x) >> 32))
   #define htonl(x) uip_htonl(x)
   #define ntohl(x) uip_ntohl(x)
 #endif
+#define htonll(x) ((1==htonl(1)) ? (x) : ((uint64_t)htonl((x) & 0xFFFFFFFF) << 32) | htonl((x) >> 32))
+#define ntohll(x) ((1==ntohl(1)) ? (x) : ((uint64_t)ntohl((x) & 0xFFFFFFFF) << 32) | ntohl((x) >> 32))
 
 #include "lwm2m_tlv.h"
 #include "lwm2m_serdes.h"

--- a/core/src/common/lwm2m_tree_builder.c
+++ b/core/src/common/lwm2m_tree_builder.c
@@ -59,7 +59,7 @@ static AwaResult ReadResourceInstanceFromStoreAndCreateTree(Lwm2mTreeNode ** des
         goto error;
     }
 
-    Lwm2m_Debug("Treebuilder length: %zd\n", valueLength);
+    Lwm2m_Debug("Treebuilder length: %d\n", (int)valueLength);
 
     if (Lwm2mTreeNode_SetValue(*dest, (const uint8_t*)value, valueLength) != 0)
     {

--- a/core/src/common/lwm2m_types.h
+++ b/core/src/common/lwm2m_types.h
@@ -28,10 +28,12 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifndef CONTIKI
+#ifdef POSIX
   #include <sys/socket.h>
   #include <netinet/in.h>
-#else
+#endif
+
+#ifdef CONTIKI
   #include "net/ip/uip.h"
 #endif
 
@@ -58,7 +60,7 @@ typedef int ObjectInstanceIDType;
 typedef int ResourceIDType;
 typedef int ResourceInstanceIDType;
 
-#ifndef CONTIKI
+#ifdef POSIX
 typedef struct
 {
     socklen_t Size;
@@ -71,11 +73,22 @@ typedef struct
     } Addr;
     bool Secure;
 } AddressType;
-#else
+#endif
+
+#ifdef CONTIKI
 typedef struct
 {
     int Port;
     uip_ipaddr_t Addr;
+    bool Secure;
+} AddressType;
+#endif
+
+#ifdef MICROCHIP_PIC32
+typedef struct
+{
+    uint16_t Port;
+    uint32_t Address;
     bool Secure;
 } AddressType;
 #endif

--- a/core/src/common/lwm2m_types.h
+++ b/core/src/common/lwm2m_types.h
@@ -28,12 +28,12 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifdef POSIX
+#ifndef CONTIKI
+#ifndef MICROCHIP_PIC32
   #include <sys/socket.h>
   #include <netinet/in.h>
 #endif
-
-#ifdef CONTIKI
+#else
   #include "net/ip/uip.h"
 #endif
 
@@ -60,7 +60,8 @@ typedef int ObjectInstanceIDType;
 typedef int ResourceIDType;
 typedef int ResourceInstanceIDType;
 
-#ifdef POSIX
+#ifndef CONTIKI
+#ifndef MICROCHIP_PIC32
 typedef struct
 {
     socklen_t Size;
@@ -73,6 +74,7 @@ typedef struct
     } Addr;
     bool Secure;
 } AddressType;
+#endif
 #endif
 
 #ifdef CONTIKI

--- a/core/src/common/lwm2m_util.h
+++ b/core/src/common/lwm2m_util.h
@@ -61,7 +61,9 @@ int64_t ptrToInt64(void * ptr);
 void Lwm2mCore_AddressTypeToPath(char * path, size_t pathSize, AddressType * addr);
 
 #ifndef CONTIKI
+#ifndef MICROCHIP_PIC32
 const char * Lwm2mCore_DebugPrintSockAddr(const struct sockaddr * sa);
+#endif
 #endif
 const char * Lwm2mCore_DebugPrintAddress(AddressType * addr);
 

--- a/core/src/erbium/er-coap.h
+++ b/core/src/erbium/er-coap.h
@@ -43,7 +43,6 @@
 #include "er-coap-constants.h"
 #include "er-coap-conf.h"
 
-
 #ifdef CONTIKI
 
 #include "contiki-net.h"
@@ -59,9 +58,7 @@
 
 typedef uip_ipaddr_t ipaddr_t
 
-#endif
-
-#ifdef POSIX
+#else
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -78,7 +75,8 @@ typedef uip_ipaddr_t ipaddr_t
 #define MIN(n, m)   (((n) < (m)) ? (n) : (m))
 #define random_rand random
 
-#endif
+#endif // CONTIKI
+
 
 #ifndef REST_MAX_CHUNK_SIZE
 #define REST_MAX_CHUNK_SIZE (512)
@@ -107,8 +105,8 @@ typedef uip_ipaddr_t ipaddr_t
 
 #endif
 
-        /* bitmap for set options */
-        enum { OPTION_MAP_SIZE = sizeof(uint8_t) * 8 };
+/* bitmap for set options */
+enum { OPTION_MAP_SIZE = sizeof(uint8_t) * 8 };
 
 #define SET_OPTION(packet, opt) ((packet)->options[opt / OPTION_MAP_SIZE] |= 1 << (opt % OPTION_MAP_SIZE))
 #define IS_OPTION(packet, opt) ((packet)->options[opt / OPTION_MAP_SIZE] & (1 << (opt % OPTION_MAP_SIZE)))


### PR DESCRIPTION
Adapt common and client modules for pic32 with MICROCHIP_PIC32 definition
Note: pic32 specific lwm2m_util + abstraction modules created for the Microchip Wifire (chipkit) are not included.