### PR TITLE
Prevent duplicate retry on bootstrap failed

### DIFF
--- a/core/src/client/lwm2m_bootstrap.c
+++ b/core/src/client/lwm2m_bootstrap.c
@@ -259,7 +259,6 @@ void Lwm2m_UpdateBootStrapState(Lwm2mContextType * context)
             {
                 Lwm2m_Warning("HoldOff Expired - Re-attempt bootstrap\n");
                 Lwm2mCore_SetBootstrapState(context, Lwm2mBootStrapState_NotBootStrapped);
-                SendBootStrapRequest(context, SERVER_BOOTSTRAP);
             }
             break;
 


### PR DESCRIPTION
For Erbium there is no 1s delay between the first and second bootstrap retry
after bootstrap failed. Removed the first request to ensure only one request send.

Signed-off-by: Rory Latchem <rory.latchem@imgtec.com>