### PR TITLE
Support multiple instances of --objDefs/-o option with awa_clientd

### DIFF
--- a/core/src/bootstrap/lwm2m_bootstrap_server.c
+++ b/core/src/bootstrap/lwm2m_bootstrap_server.c
@@ -58,8 +58,8 @@ typedef struct
     char * InterfaceName;
     int AddressFamily;
     int CoapPort;
-    const char * Config[MAX_BOOTSTRAP_CONFIG_FILES];
-    int ConfigCount;
+    const char * ConfigFiles[MAX_BOOTSTRAP_CONFIG_FILES];
+    int NumConfigFiles;
     bool Secure;
     bool Daemonise;
     bool Verbose;
@@ -210,7 +210,7 @@ static int Bootstrap_Start(Options * options)
     // must happen after coap_Init()
     Lwm2m_RegisterObjectTypes(context);
 
-    if (!Lwm2mBootstrap_BootStrapInit(context, options->Config, options->ConfigCount))
+    if (!Lwm2mBootstrap_BootStrapInit(context, options->ConfigFiles, options->NumConfigFiles))
     {
         printf("Failed to initialise bootstrap\n");
         result = 1;
@@ -276,9 +276,9 @@ static void PrintOptions(const Options * options)
     printf("  AddressFamily  (--addressFamily)  : %d\n", options->AddressFamily == AF_INET? 4 : 6);
     printf("  Port           (--port)           : %d\n", options->CoapPort);
     int i;
-    for (i = 0; i < options->ConfigCount; ++i)
+    for (i = 0; i < options->NumConfigFiles; ++i)
     {
-        printf("  Config         (--config)         : %s\n", options->Config[i]);
+        printf("  Config         (--config)         : %s\n", options->ConfigFiles[i]);
     }
     printf("  Secure         (--secure)         : %d\n", options->Secure);
     printf("  Daemonize      (--daemonize)      : %d\n", options->Daemonise);
@@ -299,9 +299,9 @@ static int ParseOptions(int argc, char ** argv, struct gengetopt_args_info * ai,
         int i;
         for (i = 0; i < ai->config_given; ++i)
         {
-            options->Config[i] = ai->config_arg[i];
+            options->ConfigFiles[i] = ai->config_arg[i];
         }
-        options->ConfigCount = ai->config_given;
+        options->NumConfigFiles = ai->config_given;
         options->Secure = ai->secure_flag;
         options->Daemonise = ai->daemonize_flag;
         options->Verbose = ai->verbose_flag;
@@ -325,8 +325,8 @@ int main(int argc, char ** argv)
         .InterfaceName = NULL,
         .AddressFamily = AF_UNSPEC,
         .CoapPort = 0,
-        .Config = {0},
-        .ConfigCount = 0,
+        .ConfigFiles = {0},
+        .NumConfigFiles = 0,
         .Secure = false,
         .Daemonise = false,
         .Verbose = false,

--- a/core/src/client/awa_clientd.ggo
+++ b/core/src/client/awa_clientd.ggo
@@ -12,7 +12,7 @@ option "ipcPort"          i "Use port number PORT for IPC communications"       
 option "endPointName"     e "Use NAME as client end point name"                  string optional default="Awa Client"       typestr="NAME"
 option "bootstrap"        b "Use bootstrap server URI"                           string optional                            typestr="URI"
 option "factoryBootstrap" f "Load factory bootstrap information from FILE"       string optional                            typestr="FILE"
-option "objDefs"          o "Load object and resource definitions from FILE"     string optional                            typestr="FILE"
+option "objDefs"          o "Load object and resource definitions from FILE"     string optional                            typestr="FILE"  multiple(1-16)
 option "daemonize"        d "Detach process from terminal and run in the background"
                                                                                  flag off
 option "verbose"          v "Generate verbose output"                            flag off

--- a/core/src/client/awa_clientd_cmdline.c
+++ b/core/src/client/awa_clientd_cmdline.c
@@ -64,6 +64,8 @@ static int
 cmdline_parser_internal (int argc, char **argv, struct gengetopt_args_info *args_info,
                         struct cmdline_parser_params *params, const char *additional_error);
 
+static int
+cmdline_parser_required2 (struct gengetopt_args_info *args_info, const char *prog_name, const char *additional_error);
 
 const char *cmdline_parser_addressFamily_values[] = {"4", "6", 0}; /*< Possible values for addressFamily. */
 
@@ -126,6 +128,8 @@ void init_args_info(struct gengetopt_args_info *args_info)
   args_info->bootstrap_help = gengetopt_args_info_help[5] ;
   args_info->factoryBootstrap_help = gengetopt_args_info_help[6] ;
   args_info->objDefs_help = gengetopt_args_info_help[7] ;
+  args_info->objDefs_min = 1;
+  args_info->objDefs_max = 16;
   args_info->daemonize_help = gengetopt_args_info_help[8] ;
   args_info->verbose_help = gengetopt_args_info_help[9] ;
   args_info->logFile_help = gengetopt_args_info_help[10] ;
@@ -211,6 +215,51 @@ free_string_field (char **s)
     }
 }
 
+/** @brief generic value variable */
+union generic_value {
+    int int_arg;
+    char *string_arg;
+    const char *default_string_arg;
+};
+
+/** @brief holds temporary values for multiple options */
+struct generic_list
+{
+  union generic_value arg;
+  char *orig;
+  struct generic_list *next;
+};
+
+/**
+ * @brief add a node at the head of the list 
+ */
+static void add_node(struct generic_list **list) {
+  struct generic_list *new_node = (struct generic_list *) malloc (sizeof (struct generic_list));
+  new_node->next = *list;
+  *list = new_node;
+  new_node->arg.string_arg = 0;
+  new_node->orig = 0;
+}
+
+
+static void
+free_multiple_string_field(unsigned int len, char ***arg, char ***orig)
+{
+  unsigned int i;
+  if (*arg) {
+    for (i = 0; i < len; ++i)
+      {
+        free_string_field(&((*arg)[i]));
+        free_string_field(&((*orig)[i]));
+      }
+    free_string_field(&((*arg)[0])); /* free default string */
+
+    free (*arg);
+    *arg = 0;
+    free (*orig);
+    *orig = 0;
+  }
+}
 
 static void
 cmdline_parser_release (struct gengetopt_args_info *args_info)
@@ -225,8 +274,7 @@ cmdline_parser_release (struct gengetopt_args_info *args_info)
   free_string_field (&(args_info->bootstrap_orig));
   free_string_field (&(args_info->factoryBootstrap_arg));
   free_string_field (&(args_info->factoryBootstrap_orig));
-  free_string_field (&(args_info->objDefs_arg));
-  free_string_field (&(args_info->objDefs_orig));
+  free_multiple_string_field (args_info->objDefs_given, &(args_info->objDefs_arg), &(args_info->objDefs_orig));
   free_string_field (&(args_info->logFile_arg));
   free_string_field (&(args_info->logFile_orig));
   
@@ -293,6 +341,14 @@ write_into_file(FILE *outfile, const char *opt, const char *arg, const char *val
   }
 }
 
+static void
+write_multiple_into_file(FILE *outfile, int len, const char *opt, char **arg, const char *values[])
+{
+  int i;
+  
+  for (i = 0; i < len; ++i)
+    write_into_file(outfile, opt, (arg ? arg[i] : 0), values);
+}
 
 int
 cmdline_parser_dump(FILE *outfile, struct gengetopt_args_info *args_info)
@@ -319,8 +375,7 @@ cmdline_parser_dump(FILE *outfile, struct gengetopt_args_info *args_info)
     write_into_file(outfile, "bootstrap", args_info->bootstrap_orig, 0);
   if (args_info->factoryBootstrap_given)
     write_into_file(outfile, "factoryBootstrap", args_info->factoryBootstrap_orig, 0);
-  if (args_info->objDefs_given)
-    write_into_file(outfile, "objDefs", args_info->objDefs_orig, 0);
+  write_multiple_into_file(outfile, args_info->objDefs_given, "objDefs", args_info->objDefs_orig, 0);
   if (args_info->daemonize_given)
     write_into_file(outfile, "daemonize", 0, 0 );
   if (args_info->verbose_given)
@@ -376,6 +431,141 @@ gengetopt_strdup (const char *s)
   return result;
 }
 
+static char *
+get_multiple_arg_token(const char *arg)
+{
+  const char *tok;
+  char *ret;
+  size_t len, num_of_escape, i, j;
+
+  if (!arg)
+    return 0;
+
+  tok = strchr (arg, ',');
+  num_of_escape = 0;
+
+  /* make sure it is not escaped */
+  while (tok)
+    {
+      if (*(tok-1) == '\\')
+        {
+          /* find the next one */
+          tok = strchr (tok+1, ',');
+          ++num_of_escape;
+        }
+      else
+        break;
+    }
+
+  if (tok)
+    len = (size_t)(tok - arg + 1);
+  else
+    len = strlen (arg) + 1;
+
+  len -= num_of_escape;
+
+  ret = (char *) malloc (len);
+
+  i = 0;
+  j = 0;
+  while (arg[i] && (j < len-1))
+    {
+      if (arg[i] == '\\' && 
+	  arg[ i + 1 ] && 
+	  arg[ i + 1 ] == ',')
+        ++i;
+
+      ret[j++] = arg[i++];
+    }
+
+  ret[len-1] = '\0';
+
+  return ret;
+}
+
+static const char *
+get_multiple_arg_token_next(const char *arg)
+{
+  const char *tok;
+
+  if (!arg)
+    return 0;
+
+  tok = strchr (arg, ',');
+
+  /* make sure it is not escaped */
+  while (tok)
+    {
+      if (*(tok-1) == '\\')
+        {
+          /* find the next one */
+          tok = strchr (tok+1, ',');
+        }
+      else
+        break;
+    }
+
+  if (! tok || strlen(tok) == 1)
+    return 0;
+
+  return tok+1;
+}
+
+static int
+check_multiple_option_occurrences(const char *prog_name, unsigned int option_given, unsigned int min, unsigned int max, const char *option_desc);
+
+int
+check_multiple_option_occurrences(const char *prog_name, unsigned int option_given, unsigned int min, unsigned int max, const char *option_desc)
+{
+  int error_occurred = 0;
+
+  if (option_given && (min > 0 || max > 0))
+    {
+      if (min > 0 && max > 0)
+        {
+          if (min == max)
+            {
+              /* specific occurrences */
+              if (option_given != (unsigned int) min)
+                {
+                  fprintf (stderr, "%s: %s option occurrences must be %d\n",
+                    prog_name, option_desc, min);
+                  error_occurred = 1;
+                }
+            }
+          else if (option_given < (unsigned int) min
+                || option_given > (unsigned int) max)
+            {
+              /* range occurrences */
+              fprintf (stderr, "%s: %s option occurrences must be between %d and %d\n",
+                prog_name, option_desc, min, max);
+              error_occurred = 1;
+            }
+        }
+      else if (min > 0)
+        {
+          /* at least check */
+          if (option_given < min)
+            {
+              fprintf (stderr, "%s: %s option occurrences must be at least %d\n",
+                prog_name, option_desc, min);
+              error_occurred = 1;
+            }
+        }
+      else if (max > 0)
+        {
+          /* at most check */
+          if (option_given > max)
+            {
+              fprintf (stderr, "%s: %s option occurrences must be at most %d\n",
+                prog_name, option_desc, max);
+              error_occurred = 1;
+            }
+        }
+    }
+    
+  return error_occurred;
+}
 int
 cmdline_parser (int argc, char **argv, struct gengetopt_args_info *args_info)
 {
@@ -424,9 +614,34 @@ cmdline_parser2 (int argc, char **argv, struct gengetopt_args_info *args_info, i
 int
 cmdline_parser_required (struct gengetopt_args_info *args_info, const char *prog_name)
 {
-  FIX_UNUSED (args_info);
-  FIX_UNUSED (prog_name);
-  return EXIT_SUCCESS;
+  int result = EXIT_SUCCESS;
+
+  if (cmdline_parser_required2(args_info, prog_name, 0) > 0)
+    result = EXIT_FAILURE;
+
+  if (result == EXIT_FAILURE)
+    {
+      cmdline_parser_free (args_info);
+      exit (EXIT_FAILURE);
+    }
+  
+  return result;
+}
+
+int
+cmdline_parser_required2 (struct gengetopt_args_info *args_info, const char *prog_name, const char *additional_error)
+{
+  int error_occurred = 0;
+  FIX_UNUSED (additional_error);
+
+  /* checks for required options */
+  if (check_multiple_option_occurrences(prog_name, args_info->objDefs_given, args_info->objDefs_min, args_info->objDefs_max, "'--objDefs' ('-o')"))
+     error_occurred = 1;
+  
+  
+  /* checks for dependences among options */
+
+  return error_occurred;
 }
 
 /*
@@ -1148,6 +1363,137 @@ int update_arg(void *field, char **orig_field,
   return 0; /* OK */
 }
 
+/**
+ * @brief store information about a multiple option in a temporary list
+ * @param list where to (temporarily) store multiple options
+ */
+static
+int update_multiple_arg_temp(struct generic_list **list,
+               unsigned int *prev_given, const char *val,
+               const char *possible_values[], const char *default_value,
+               cmdline_parser_arg_type arg_type,
+               const char *long_opt, char short_opt,
+               const char *additional_error)
+{
+  /* store single arguments */
+  char *multi_token;
+  const char *multi_next;
+
+  if (arg_type == ARG_NO) {
+    (*prev_given)++;
+    return 0; /* OK */
+  }
+
+  multi_token = get_multiple_arg_token(val);
+  multi_next = get_multiple_arg_token_next (val);
+
+  while (1)
+    {
+      add_node (list);
+      if (update_arg((void *)&((*list)->arg), &((*list)->orig), 0,
+          prev_given, multi_token, possible_values, default_value, 
+          arg_type, 0, 1, 1, 1, long_opt, short_opt, additional_error)) {
+        if (multi_token) free(multi_token);
+        return 1; /* failure */
+      }
+
+      if (multi_next)
+        {
+          multi_token = get_multiple_arg_token(multi_next);
+          multi_next = get_multiple_arg_token_next (multi_next);
+        }
+      else
+        break;
+    }
+
+  return 0; /* OK */
+}
+
+/**
+ * @brief free the passed list (including possible string argument)
+ */
+static
+void free_list(struct generic_list *list, short string_arg)
+{
+  if (list) {
+    struct generic_list *tmp;
+    while (list)
+      {
+        tmp = list;
+        if (string_arg && list->arg.string_arg)
+          free (list->arg.string_arg);
+        if (list->orig)
+          free (list->orig);
+        list = list->next;
+        free (tmp);
+      }
+  }
+}
+
+/**
+ * @brief updates a multiple option starting from the passed list
+ */
+static
+void update_multiple_arg(void *field, char ***orig_field,
+               unsigned int field_given, unsigned int prev_given, union generic_value *default_value,
+               cmdline_parser_arg_type arg_type,
+               struct generic_list *list)
+{
+  int i;
+  struct generic_list *tmp;
+
+  if (prev_given && list) {
+    *orig_field = (char **) realloc (*orig_field, (field_given + prev_given) * sizeof (char *));
+
+    switch(arg_type) {
+    case ARG_INT:
+      *((int **)field) = (int *)realloc (*((int **)field), (field_given + prev_given) * sizeof (int)); break;
+    case ARG_STRING:
+      *((char ***)field) = (char **)realloc (*((char ***)field), (field_given + prev_given) * sizeof (char *)); break;
+    default:
+      break;
+    };
+    
+    for (i = (prev_given - 1); i >= 0; --i)
+      {
+        tmp = list;
+        
+        switch(arg_type) {
+        case ARG_INT:
+          (*((int **)field))[i + field_given] = tmp->arg.int_arg; break;
+        case ARG_STRING:
+          (*((char ***)field))[i + field_given] = tmp->arg.string_arg; break;
+        default:
+          break;
+        }        
+        (*orig_field) [i + field_given] = list->orig;
+        list = list->next;
+        free (tmp);
+      }
+  } else { /* set the default value */
+    if (default_value && ! field_given) {
+      switch(arg_type) {
+      case ARG_INT:
+        if (! *((int **)field)) {
+          *((int **)field) = (int *)malloc (sizeof (int));
+          (*((int **)field))[0] = default_value->int_arg; 
+        }
+        break;
+      case ARG_STRING:
+        if (! *((char ***)field)) {
+          *((char ***)field) = (char **)malloc (sizeof (char *));
+          (*((char ***)field))[0] = gengetopt_strdup(default_value->string_arg);
+        }
+        break;
+      default: break;
+      }
+      if (!(*orig_field)) {
+        *orig_field = (char **) malloc (sizeof (char *));
+        (*orig_field)[0] = 0;
+      }
+    }
+  }
+}
 
 int
 cmdline_parser_internal (
@@ -1156,6 +1502,7 @@ cmdline_parser_internal (
 {
   int c;	/* Character of the parsed option.  */
 
+  struct generic_list * objDefs_list = NULL;
   int error_occurred = 0;
   struct gengetopt_args_info local_args_info;
   
@@ -1301,11 +1648,8 @@ cmdline_parser_internal (
           break;
         case 'o':	/* Load object and resource definitions from FILE.  */
         
-        
-          if (update_arg( (void *)&(args_info->objDefs_arg), 
-               &(args_info->objDefs_orig), &(args_info->objDefs_given),
+          if (update_multiple_arg_temp(&objDefs_list, 
               &(local_args_info.objDefs_given), optarg, 0, 0, ARG_STRING,
-              check_ambiguity, override, 0, 0,
               "objDefs", 'o',
               additional_error))
             goto failure;
@@ -1366,7 +1710,18 @@ cmdline_parser_internal (
     } /* while */
 
 
+  update_multiple_arg((void *)&(args_info->objDefs_arg),
+    &(args_info->objDefs_orig), args_info->objDefs_given,
+    local_args_info.objDefs_given, 0,
+    ARG_STRING, objDefs_list);
 
+  args_info->objDefs_given += local_args_info.objDefs_given;
+  local_args_info.objDefs_given = 0;
+  
+  if (check_required)
+    {
+      error_occurred += cmdline_parser_required2 (args_info, argv[0], additional_error);
+    }
 
   cmdline_parser_release (&local_args_info);
 
@@ -1392,6 +1747,7 @@ cmdline_parser_internal (
   return 0;
 
 failure:
+  free_list (objDefs_list, 1 );
   
   cmdline_parser_release (&local_args_info);
   return (EXIT_FAILURE);

--- a/core/src/client/awa_clientd_cmdline.h
+++ b/core/src/client/awa_clientd_cmdline.h
@@ -56,8 +56,10 @@ struct gengetopt_args_info
   char * factoryBootstrap_arg;	/**< @brief Load factory bootstrap information from FILE.  */
   char * factoryBootstrap_orig;	/**< @brief Load factory bootstrap information from FILE original value given at command line.  */
   const char *factoryBootstrap_help; /**< @brief Load factory bootstrap information from FILE help description.  */
-  char * objDefs_arg;	/**< @brief Load object and resource definitions from FILE.  */
-  char * objDefs_orig;	/**< @brief Load object and resource definitions from FILE original value given at command line.  */
+  char ** objDefs_arg;	/**< @brief Load object and resource definitions from FILE.  */
+  char ** objDefs_orig;	/**< @brief Load object and resource definitions from FILE original value given at command line.  */
+  unsigned int objDefs_min; /**< @brief Load object and resource definitions from FILE's minimum occurreces */
+  unsigned int objDefs_max; /**< @brief Load object and resource definitions from FILE's maximum occurreces */
   const char *objDefs_help; /**< @brief Load object and resource definitions from FILE help description.  */
   int daemonize_flag;	/**< @brief Detach process from terminal and run in the background (default=off).  */
   const char *daemonize_help; /**< @brief Detach process from terminal and run in the background help description.  */


### PR DESCRIPTION
to enable loading of multiple object and resource definition files.

Signed-off-by: David Antliff <david.antliff@imgtec.com>