### PR TITLE
Change log output from CyaSSL

### DIFF
--- a/core/src/common/dtls_abstraction_cyassl.c
+++ b/core/src/common/dtls_abstraction_cyassl.c
@@ -207,7 +207,7 @@ bool DTLS_Decrypt(NetworkAddress * sourceAddress, uint8_t * encrypted, int encry
                 session->SessionEstablished = (acceptResult == SSL_SUCCESS);
             }
             if (session->SessionEstablished)
-                Lwm2m_Info("Session established");
+                Lwm2m_Info("DTLS session established\n");
         }
     }
     return result;
@@ -242,7 +242,7 @@ bool DTLS_Encrypt(NetworkAddress * destAddress, uint8_t * plainText, int plainTe
             else
                 session->SessionEstablished = (CyaSSL_accept(session->Session) == SSL_SUCCESS);
             if (session->SessionEstablished)
-                Lwm2m_Info("Session established");
+                Lwm2m_Info("DTLS session established\n");
         }
     }
     else


### PR DESCRIPTION
Adapt logging so DTLS session established can be seen on clients during startup

Signed-off-by: Rory Latchem <rory.latchem@imgtec.com>