### PR TITLE
Add option to turning off building examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ option (RUN_TESTS "Enable tests" OFF)
 option (WITH_JSON "Enable JSON support" OFF)
 # cmdline: cmake -DBUILD_TESTS=ON -DRUN_TESTS=OFF ..
 
-# build tests, but disable running by default
+# build examples
 option (BUILD_EXAMPLES "Build examples" ON)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,10 @@ option (RUN_TESTS "Enable tests" OFF)
 option (WITH_JSON "Enable JSON support" OFF)
 # cmdline: cmake -DBUILD_TESTS=ON -DRUN_TESTS=OFF ..
 
+# build tests, but disable running by default
+option (BUILD_EXAMPLES "Build examples" ON)
+
+
 option (ENABLE_GCOV "Enable code coverage check" OFF)
 # cmake -DENABLE_GCOV=ON ..
 

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -1,7 +1,9 @@
 set (API_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include CACHE INTERNAL "API_INCLUDE_DIR")
 
 add_subdirectory (src)
+if (BUILD_EXAMPLES)
 add_subdirectory (examples)
+endif ()
 
 if (BUILD_TESTS)
   add_subdirectory (tests)


### PR DESCRIPTION
Add option to turning off building examples (which is still on by default)