### PR TITLE
Update CONTRIBUTORS.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,9 +1,10 @@
-Chris Dewbery <christopher.dewbery@imgtec.com>
-Sean Kelly <sean.kelly@imgtec.com>
+Chris Dewbery
+Sean Kelly
 David Antliff
 Roland Bewick <roland.bewick@imgtec.com>
 Hayden Brown <hayden.brown@imgtec.com>
 Tony Walsworth <tony.walsworth@imgtec.com>
 Rory Latchem <rory.latchem@imgtec.com>
-Surender Sanke <surender.sanke@imgtec.com>
-Janibasha Shaik <janibasha.shaik@imgtec.com>
+Delme Thomas
+Surender Sanke
+Janibasha Shaik


### PR DESCRIPTION
Several email addresses are no longer valid and have been removed.

If you are a contributor, please add your own non-IMG address if you wish.

Also added @delme-imgtec (with no email address, as it's not my call to add one).

Signed-off-by: David Antliff <david.antliff@gmail.com>