### PR TITLE
Fix Python API's observe request

### DIFF
--- a/api/python/ipc_lwm2m_server.py
+++ b/api/python/ipc_lwm2m_server.py
@@ -223,6 +223,7 @@ class DeleteResponse(IpcResponse):
 class ObserveRequest(IpcRequest):
     MessageType = "Observe"
     SupportedModelPaths = ( "O", "OI", "OIR" )
+    PathLabel = "Observe"
     def add(self, path, value=None):
         super(ObserveRequest, self).add(path, None)
 

--- a/api/python/tests/test_ipc_lwm2m_server.py
+++ b/api/python/tests/test_ipc_lwm2m_server.py
@@ -526,6 +526,7 @@ class TestLWM2MServerIpcRequests(xml_test_case.XmlTestCase):
                       <ID>2</ID>
                       <Resource>
                         <ID>3</ID>
+                        <Observe/>
                       </Resource>
                     </ObjectInstance>
                   </Object>
@@ -552,6 +553,7 @@ class TestLWM2MServerIpcRequests(xml_test_case.XmlTestCase):
                     <ID>1</ID>
                     <ObjectInstance>
                       <ID>2</ID>
+                      <Observe/>
                     </ObjectInstance>
                   </Object>
                 </Objects>
@@ -575,6 +577,7 @@ class TestLWM2MServerIpcRequests(xml_test_case.XmlTestCase):
                 <Objects>
                   <Object>
                     <ID>1</ID>
+                    <Observe/>
                   </Object>
                 </Objects>
               </Client>


### PR DESCRIPTION
According to the docs the observe request needs an \<Observe/\> tag:
https://github.com/FlowM2M/AwaLWM2M/blob/master/doc/ipc.md#observe
