### PR TITLE
Python API: Make the API Python 2 & 3 compatible

### DIFF
--- a/api/python/ipc_lwm2m_client.py
+++ b/api/python/ipc_lwm2m_client.py
@@ -24,7 +24,11 @@
 LWM2M Client IPC Interface
 """
 
-from lxml import etree
+try:
+    import lxml.etree as ElementTree
+except ImportError:
+    import xml.etree.ElementTree as ElementTree
+
 from ipc_core import IpcRequest, IpcResponse, IpcNotification
 
 

--- a/api/python/ipc_lwm2m_server.py
+++ b/api/python/ipc_lwm2m_server.py
@@ -24,7 +24,11 @@
 LWM2M Server IPC Interface
 """
 
-from lxml import etree
+try:
+    import lxml.etree as ElementTree
+except ImportError:
+    import xml.etree.ElementTree as ElementTree
+
 import ipc_core
 
 class IpcError(Exception):
@@ -96,10 +100,10 @@ class ContentClientID(ipc_core.IpcContent):
         model.add(path, value, label)
 
     def getElement(self):
-        e_content = etree.Element("Content")
-        e_clients = etree.Element("Clients")
+        e_content = ElementTree.Element("Content")
+        e_clients = ElementTree.Element("Clients")
         for client_id in self._clients:
-            e_client = etree.Element("Client")
+            e_client = ElementTree.Element("Client")
             e_client.append(ipc_core.TElement("ID", str(client_id)))
             e_model = self._clients[client_id].model.getElement()
             # strip the outer container

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,3 +1,4 @@
 mercurial==3.7
 nose==1.3.7
 lxml==3.6.0
+future==0.16.0


### PR DESCRIPTION
Based on #305 

Removes the requirement for lxml, while also adding a requirement for the future package (only for iteritems for now). ElementTree is significantly slower than lxml, however it makes for an easier use out of the box on the Ci40. Future package can be easily installed via 'pip install future'