### PR TITLE
Add release build to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,12 @@ option (WITH_TINYDTLS "Enable TinyDTLS DTLS support" OFF)
 option (WITH_MBEDTLS "Enable mbedTLS DTLS support" OFF)
 option (WITH_SYSTEMD "Install systemd service files" OFF)
 
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING
+      "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
+endif(NOT CMAKE_BUILD_TYPE)
+
 if (WITH_LIBCOAP)
   message (WARNING "Disabling erbium support")
   set (WITH_ERBIUM OFF)
@@ -50,7 +56,7 @@ if (RUN_TESTS)
   set (BUILD_TESTS ON)
 endif ()
 
-if (CMAKE_CROSSCOMPILING)
+if ((CMAKE_CROSSCOMPILING) OR (CMAKE_BUILD_TYPE STREQUAL "Release"))
   set (BUILD_TESTS OFF)
   set (RUN_TESTS OFF)
   set (ENABLE_GCOV OFF)
@@ -60,10 +66,11 @@ endif ()
 #execute_process (COMMAND git describe --abbrev=4 --dirty --always --tags OUTPUT_VARIABLE VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
 file (STRINGS "VERSION" VERSION)
 
+set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -ggdb")
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 # enable debugging info for all components
-# TODO: separate debug and release builds
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb")
-add_compile_options (-g)
+  add_compile_options (-g)
+endif ()
 
 # build libraries
 add_subdirectory (lib)

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,10 @@ INSTALL_PREFIX:=/
 ###############################################################################
 # Rules
 
-ifeq ($(DEBUG),)
-#  override CMAKE_OPTIONS+=-DCMAKE_BUILD_TYPE=Release
+DEBUG?=1
+
+ifeq ($(DEBUG),0)
+  override CMAKE_OPTIONS+=-DCMAKE_BUILD_TYPE=Release
 else
   override CMAKE_OPTIONS+=-DCMAKE_BUILD_TYPE=Debug
 endif

--- a/api/src/CMakeLists.txt
+++ b/api/src/CMakeLists.txt
@@ -74,11 +74,12 @@ set (Awa_SOURCES
   ${DAEMON_SRC_DIR}/common/lwm2m_xml_serdes.c
 )
 
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Werror -D_GNU_SOURCE")
+set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -Wall -Werror -D_GNU_SOURCE")
+set (CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Os -Wall -Werror -D_GNU_SOURCE")
 
 if (ENABLE_GCOV)
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 --coverage")
-  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+  set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -O0 --coverage")
+  set (CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} --coverage")
 endif ()
 
 # Virtual library to avoid building .o files twice:

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 set (CORE_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "CORE_SRC_DIR")
 
-set (CMAKE_C_FLAGS "-Wall -Werror -Wno-pointer-sign -g -DVERSION='\"${VERSION}\"' -D_GNU_SOURCE")
+set (CMAKE_C_FLAGS_DEBUG "-Wall -Werror -Wno-pointer-sign -g -DVERSION='\"${VERSION}\"' -D_GNU_SOURCE")
+set (CMAKE_C_FLAGS_RELEASE "-Os -Wall -Werror -Wno-pointer-sign -DVERSION='\"${VERSION}\"' -D_GNU_SOURCE")
 #SET(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
 
 add_subdirectory (common)

--- a/core/src/bootstrap/CMakeLists.txt
+++ b/core/src/bootstrap/CMakeLists.txt
@@ -47,8 +47,8 @@ endif ()
 add_definitions (-DLWM2M_BOOTSTRAP)
 
 if (ENABLE_GCOV)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 --coverage")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -O0 --coverage")
+  set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} --coverage")
 endif ()
 
 # Virtual library to avoid building .o files twice:

--- a/core/src/client/CMakeLists.txt
+++ b/core/src/client/CMakeLists.txt
@@ -55,8 +55,8 @@ endif ()
 add_definitions (-DLWM2M_CLIENT)
 
 if (ENABLE_GCOV)
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 --coverage")
-  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+  set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -O0 --coverage")
+  set (CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} --coverage")
 endif ()
 
 # static library libawa_static.a

--- a/core/src/common/CMakeLists.txt
+++ b/core/src/common/CMakeLists.txt
@@ -102,8 +102,8 @@ if (WITH_MBEDTLS)
 endif ()
 
 if (ENABLE_GCOV)
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 --coverage")
-  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+  set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -O0 --coverage")
+  set (CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} --coverage")
 endif ()
 
 # Virtual library to avoid building .o files twice:

--- a/core/src/erbium/CMakeLists.txt
+++ b/core/src/erbium/CMakeLists.txt
@@ -38,8 +38,8 @@ set (awa_erbium_LIBS
 )
 
 if (ENABLE_GCOV)
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 --coverage")
-  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+  set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -O0 --coverage")
+  set (CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} --coverage")
 endif ()
 
 # From Contiki Makefiles

--- a/core/src/server/CMakeLists.txt
+++ b/core/src/server/CMakeLists.txt
@@ -45,8 +45,8 @@ endif ()
 add_definitions (-DLWM2M_SERVER)
 
 if (ENABLE_GCOV)
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 --coverage")
-  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+  set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -O0 --coverage")
+  set (CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} --coverage")
 endif ()
 
 # Virtual library to avoid building .o files twice:

--- a/daemon/src/CMakeLists.txt
+++ b/daemon/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 set (DAEMON_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "DAEMON_SRC_DIR")
 
-set (CMAKE_C_FLAGS "-Wall -Werror -Wno-pointer-sign -g -DVERSION='\"${VERSION}\"' -D_GNU_SOURCE")
+set (CMAKE_C_FLAGS_DEBUG "-Wall -Werror -Wno-pointer-sign -g -DVERSION='\"${VERSION}\"' -D_GNU_SOURCE")
+set (CMAKE_C_FLAGS_RELEASE "-Os -Wall -Werror -Wno-pointer-sign -DVERSION='\"${VERSION}\"' -D_GNU_SOURCE")
 #SET(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
 
 add_subdirectory (bootstrap)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -21,11 +21,12 @@ set (DefineTools
   awa-client-define
 )
 
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Werror")
+set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -Wall -Werror")
+set (CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Os -Wall -Werror")
 
 if (ENABLE_GCOV)
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 --coverage")
-  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+  set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -O0 --coverage")
+  set (CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} --coverage")
 endif ()
 
 # Virtual library to avoid building .o files twice:


### PR DESCRIPTION
Improve the build so that smaller binaries can be built (#330):

make DEBUG=0 will enable the release build in CMake, default build is debug with existing debug options.