### PR TITLE
Handle sendto() function failure conditions

### DIFF
--- a/core/src/common/network_abstraction_linux.c
+++ b/core/src/common/network_abstraction_linux.c
@@ -780,21 +780,11 @@ bool sendUDP(NetworkSocket * networkSocket, NetworkAddress * destAddress, const 
         int lastError = errno;
         if (sentBytes == SOCKET_ERROR)
         {
-            if (lastError == EWOULDBLOCK)
+            if ((lastError == EWOULDBLOCK) || (lastError == EINTR))
             {
                 sentBytes = 0;
             }
-            else if (lastError == ENOTCONN)
-            {
-                networkSocket->LastError = NetworkSocketError_SendError;
-                break;
-            }
-            else if (lastError == ECONNRESET)
-            {
-                networkSocket->LastError = NetworkSocketError_SendError;
-                break;
-            }
-            else if (lastError == EBADF)
+            else
             {
                 networkSocket->LastError = NetworkSocketError_SendError;
                 break;


### PR DESCRIPTION
The sendto() function can fail because of  multiple conditions.
Currently we are handling few conditions. If there is an error due
to another condition, the process gets stuck in repeatedly trying
to call sendto() function and failing with the same error condition.
For example, when awa session is established and after that
network interface goes down(ex. ethernet cable is removed),
the sendto() fuction fails with error 'ENETUNREACH'. This error
is not handled and the process gets stuck in repeatedly calling
sendto() fuction. There are also other possible error conditions.
In this change handling all error conditions, so that process
does not get stuck in endless loop.

Ref: AWA-311
Signed-off-by: Pranit Tanaji Sirsat <Pranit.Sirsat@imgtec.com>