### PR TITLE
Static library build for RIOT

### DIFF
--- a/core/src/client/CMakeLists.txt
+++ b/core/src/client/CMakeLists.txt
@@ -63,7 +63,7 @@ endif ()
 add_library (awa_static STATIC  ${awa_client_static_SOURCES})
 target_include_directories (awa_static PUBLIC ${awa_client_static_INCLUDE_DIRS})
 set_property (TARGET awa_static PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_link_libraries (awa_static awa_common_static libb64_static libhmac_static)
+target_link_libraries (awa_static awa_common_static)
 
 # libawa_static.so
 add_library (awa_static_shared SHARED ${awa_client_static_SOURCES})

--- a/core/src/client/lwm2m_static.c
+++ b/core/src/client/lwm2m_static.c
@@ -435,11 +435,11 @@ static AwaResult DefaultHandler(AwaStaticClient * client, AwaOperation operation
                 {
                     if (resourceDefinition->IsPointerArray)
                     {
-                        offset = resourceDefinition->DataPointers + (objectInstanceID * sizeof(void*));
+                        offset = (char *)resourceDefinition->DataPointers + (objectInstanceID * sizeof(void*));
                     }
                     else
                     {
-                        offset = resourceDefinition->DataPointers + (resourceDefinition->DataStepSize * objectInstanceID);
+                        offset = (char *)resourceDefinition->DataPointers + (resourceDefinition->DataStepSize * objectInstanceID);
                     }
 
                     if (*dataSize <= resourceDefinition->DataElementSize)
@@ -468,11 +468,11 @@ static AwaResult DefaultHandler(AwaStaticClient * client, AwaOperation operation
                 {
                     if (resourceDefinition->IsPointerArray)
                     {
-                        offset = resourceDefinition->DataPointers + (objectInstanceID * sizeof(void*));
+                        offset = (char *)resourceDefinition->DataPointers + (objectInstanceID * sizeof(void*));
                     }
                     else
                     {
-                        offset = resourceDefinition->DataPointers + (resourceDefinition->DataStepSize * objectInstanceID);
+                        offset = (char *)resourceDefinition->DataPointers + (resourceDefinition->DataStepSize * objectInstanceID);
                     }
 
                     *dataPointer = offset;

--- a/core/src/common/CMakeLists.txt
+++ b/core/src/common/CMakeLists.txt
@@ -62,11 +62,6 @@ if (WITH_TINYDTLS)
 endif ()
 
 
-#set (awa_common_LIBS
-#  libxml_static
-#  libb64_static
-#)
-
 if (WITH_LIBCOAP)
   list (APPEND awa_common_LIBS libcoap_static)
 endif ()
@@ -82,6 +77,7 @@ if (WITH_JSON)
   )
   list (APPEND awa_common_LIBS
     libjsmn_static
+    libb64_static
   )
 endif ()
 

--- a/core/src/common/CMakeLists.txt
+++ b/core/src/common/CMakeLists.txt
@@ -62,10 +62,10 @@ if (WITH_TINYDTLS)
 endif ()
 
 
-set (awa_common_LIBS
-  libxml_static
-  libb64_static
-)
+#set (awa_common_LIBS
+#  libxml_static
+#  libb64_static
+#)
 
 if (WITH_LIBCOAP)
   list (APPEND awa_common_LIBS libcoap_static)

--- a/core/src/common/lwm2m_tlv.c
+++ b/core/src/common/lwm2m_tlv.c
@@ -41,8 +41,8 @@
   #define htonl(x) uip_htonl(x)
   #define ntohl(x) uip_ntohl(x)
 #endif
-#define htonll(x) ((1==htonl(1)) ? (x) : ((uint64_t)htonl((x) & 0xFFFFFFFF) << 32) | htonl((x) >> 32))
-#define ntohll(x) ((1==ntohl(1)) ? (x) : ((uint64_t)ntohl((x) & 0xFFFFFFFF) << 32) | ntohl((x) >> 32))
+#define htonll(x) ((1==htonl(1)) ? (uint64_t)(x) : ((uint64_t)htonl((x) & 0xFFFFFFFF) << 32) | htonl((x) >> 32))
+#define ntohll(x) ((1==ntohl(1)) ? (uint64_t)(x) : ((uint64_t)ntohl((x) & 0xFFFFFFFF) << 32) | ntohl((x) >> 32))
 
 #include "lwm2m_tlv.h"
 #include "lwm2m_serdes.h"

--- a/core/src/erbium/CMakeLists.txt
+++ b/core/src/erbium/CMakeLists.txt
@@ -31,12 +31,6 @@ set (awa_erbium_INCLUDE_DIRS
   #${CORE_SRC_DIR}/../../api/include
 )
 
-# TODO - remove
-#set (awa_erbium_LIBS
-#  libb64_static
-#  libhmac_static
-#)
-
 if (ENABLE_GCOV)
   set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -O0 --coverage")
   set (CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} --coverage")

--- a/core/src/erbium/CMakeLists.txt
+++ b/core/src/erbium/CMakeLists.txt
@@ -32,10 +32,10 @@ set (awa_erbium_INCLUDE_DIRS
 )
 
 # TODO - remove
-set (awa_erbium_LIBS
-  libb64_static
-  libhmac_static
-)
+#set (awa_erbium_LIBS
+#  libb64_static
+#  libhmac_static
+#)
 
 if (ENABLE_GCOV)
   set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -O0 --coverage")

--- a/daemon/src/bootstrap/CMakeLists.txt
+++ b/daemon/src/bootstrap/CMakeLists.txt
@@ -34,7 +34,7 @@ set_source_files_properties (awa_bootstrapd_cmdline.c PROPERTIES COMPILE_FLAGS -
 
 add_executable (awa_bootstrapd ${awa_bootstrapd_SOURCES})
 target_include_directories (awa_bootstrapd PRIVATE ${awa_bootstrapd_INCLUDE_DIRS})
-target_link_libraries (awa_bootstrapd awa_bootstrap_server_static awa_common_static)
+target_link_libraries (awa_bootstrapd awa_bootstrap_server_static awa_common_static libb64_static libxml_static)
 
 if (ENABLE_GCOV)
   target_link_libraries (awa_bootstrapd gcov)

--- a/daemon/src/client/CMakeLists.txt
+++ b/daemon/src/client/CMakeLists.txt
@@ -75,7 +75,7 @@ set_source_files_properties (awa_clientd_cmdline.c PROPERTIES COMPILE_FLAGS -Wno
 
 add_executable (awa_clientd ${awa_clientd_SOURCES})
 target_include_directories (awa_clientd PRIVATE ${awa_clientd_INCLUDE_DIRS})
-target_link_libraries (awa_clientd awa_static awa_common_static libb64_static libhmac_static)
+target_link_libraries (awa_clientd awa_static awa_common_static libb64_static libhmac_static libb64_static libxml_static)
 
 if (ENABLE_GCOV)
   target_link_libraries (awa_clientd gcov)

--- a/daemon/src/server/CMakeLists.txt
+++ b/daemon/src/server/CMakeLists.txt
@@ -77,7 +77,7 @@ set_source_files_properties (awa_serverd_cmdline.c PROPERTIES COMPILE_FLAGS -Wno
 
 add_executable (awa_serverd ${awa_serverd_SOURCES})
 target_include_directories (awa_serverd PRIVATE ${awa_serverd_INCLUDE_DIRS})
-target_link_libraries (awa_serverd awa_server_static awa_common_static)
+target_link_libraries (awa_serverd awa_server_static awa_common_static libb64_static libxml_static)
 
 if (ENABLE_GCOV)
    target_link_libraries (awa_serverd gcov)

--- a/daemon/tests/CMakeLists.txt
+++ b/daemon/tests/CMakeLists.txt
@@ -42,6 +42,8 @@ set (test_daemon_runner_LIBRARIES
   pthread
   awa_static
   awa_common_static
+  libxml_static
+  libb64_static
 )
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -g -std=c++11")


### PR DESCRIPTION
See https://github.com/datachi7d/RIOT/tree/awa for RIOT build:

```
# git clone https://github.com/datachi7d/RIOT.git --branch awa --depth 1
# cd RIOT
# make -C examples/AwaLWM2M-client/
```

Note: this does not use the RIOT network stack - still work to do there. I didn't have much luck with the RIOT POSIX socket implementation with network_abstraction_linux.c, so possibly network_abstraction_riot.c is needed.