### PR TITLE
Fix missing macro in RIOT utilities

### DIFF
--- a/core/src/common/lwm2m_util_riot.c
+++ b/core/src/common/lwm2m_util_riot.c
@@ -25,6 +25,8 @@
 #include "net/sock/dns.h"
 #include "net/sock/util.h"
 
+#define POSIX_DNS_SERVER "53"
+
 sock_udp_ep_t sock_dns_server;
 
 // Get the system tick count in milliseconds


### PR DESCRIPTION
Signed-off-by: Sean Kelly <seandtkelly@gmail.com>